### PR TITLE
Fix runtime error that there aren't parameter files.

### DIFF
--- a/src/magic.ts
+++ b/src/magic.ts
@@ -278,7 +278,7 @@ function loadFile(filePath: string) {
         return
       }
 
-      if (files.length) {
+      if (files.length > 0) {
         const ext = path.extname(files[0])
 
         if (ext === ".js") {


### PR DESCRIPTION
This patch will make the spear-cli to allow execute no parameter files. Before this commit, 'spear-cli' fault the runtime error.