### PR TITLE
1.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spear-cli",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "spear-cli",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "@types/live-server": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spear-cli",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "type": "module",
   "description": "",
   "preferGlobal": true,


### PR DESCRIPTION
@yoannes 

Sorry!! 🙇🏼‍♂️ 
I'll update the version since I've changed the version before `npm publish`.
So `spear-cli` was skipped v1.0.12..

This PR is changing version to published version.