### PR TITLE
Add sitemap generation feature

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -40,7 +40,8 @@
     "inquirer": "^9.0.2",
     "live-server": "^1.2.2",
     "node-html-parser": "^5.3.3",
-    "node-watch": "^0.7.3"
+    "node-watch": "^0.7.3",
+    "sitemap": "^7.1.1"
   },
   "devDependencies": {
     "@types/argparse": "^2.0.10",

--- a/packages/spear-cli/src/create.ts
+++ b/packages/spear-cli/src/create.ts
@@ -19,6 +19,8 @@ const settings = {
     templateType: "basic",
     useCMS: "",
     spearlyCMSApiKey: "",
+    generateSitemap: "",
+    siteURL: "",
   },
   projectDir: dirname.split("/").slice(-1)[0],
 }
@@ -43,6 +45,12 @@ async function askQuestions() {
       choices: ["Yes", "No"],
     },
     {
+      name: "spearlyCMSApiKey",
+      type: "input",
+      message: "Enter your Spearly CMS API KEY",
+      when: (answers) => answers.useCMS === "Yes",
+    },
+    {
       name: "templateType",
       type: "list",
       message: "Choose template type",
@@ -50,10 +58,26 @@ async function askQuestions() {
       choices: ["basic", "empty"],
     },
     {
-      name: "spearlyCMSApiKey",
+      name: "generateSitemap",
+      message: "Generate Sitemap?",
+      type: "list",
+      default: "No",
+      choices: ["Yes", "No"],
+    },
+    {
+      name: "siteURL",
+      message: "Enter your hosting URL (Example: https://foobar.netlify.app/)",
       type: "input",
-      message: "Enter your Spearly CMS API KEY",
-      when: (answers) => answers.useCMS === "Yes",
+      default: "",
+      validate: (input) => {
+        try {
+          new URL(input)
+        } catch (e) {
+          return "input correct URL syntax. (Example: https://foobar.netlify.app/foo/";
+        }
+        return true;
+      },
+      when: (answer) => answer.generateSitemap === "Yes",
     },
   ]
 
@@ -127,6 +151,8 @@ async function createBoilerplate() {
     settingsFile.spearlyAuthKey = settings.answers.spearlyCMSApiKey
   }
   settingsFile.projectName = settings.answers.projectName
+  settingsFile.generateSitemap = settings.answers.generateSitemap === "Yes"
+  settingsFile.siteURL = settings.answers.siteURL
   if (Object.keys(settingsFile).length) {
     fs.writeFileSync(
       `${basePath}/spear.config.js`,

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -11,4 +11,6 @@ export interface DefaultSettings {
   port?: number
   host?: string
   apiDomain: string,
+  generateSitemap: boolean,
+  siteURL: string,
 }

--- a/packages/spear-cli/src/interfaces/magicInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/magicInterfaces.ts
@@ -26,3 +26,9 @@ export interface State {
     assetsFiles: AssetFile[]
   }
 }
+
+export interface SiteMapURL {
+  url: string,
+  changefreq: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never",
+  priority: number,
+}

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -104,6 +104,18 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
+"@types/node@^17.0.5":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
+  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/sax@^1.2.1":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.4.tgz#8221affa7f4f3cb21abd22f244cfabfa63e6a69e"
+  integrity sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/through@*":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
@@ -192,6 +204,11 @@ apache-md5@^1.0.6:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/apache-md5/-/apache-md5-1.1.8.tgz#ea79c6feb03abfed42b2830dde06f75df5e3bbd9"
   integrity sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==
+
+arg@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -2314,6 +2331,11 @@ sass@^1.57.1:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -2413,6 +2435,16 @@ simple-update-notifier@^1.0.7:
   integrity sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==
   dependencies:
     semver "~7.0.0"
+
+sitemap@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-7.1.1.tgz#eeed9ad6d95499161a3eadc60f8c6dce4bea2bef"
+  integrity sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==
+  dependencies:
+    "@types/node" "^17.0.5"
+    "@types/sax" "^1.2.1"
+    arg "^5.0.0"
+    sax "^1.2.4"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
## Change

Support Sitemap generation based on #57 

## Sitemap Generation

- Add flag whether using sitemap generation feature. (Add `generateSitemap` / `siteURL` option into `spear.config.js`)
- Ask enabling the site generation feature when creating project.
- Generate `sitemap.xml` when building.

### Note that:
- change frequency is fixed. (`daily`)
- priorigy is fixed as well. (`0.7`)

### Generated sitemap.xml example

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset
    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
    xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
    xmlns:xhtml="http://www.w3.org/1999/xhtml"
    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
    xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
    <url>
        <loc>https://mantaroh.org/index.html</loc>
        <changefreq>daily</changefreq>
        <priority>0.7</priority>
    </url>
    <url>
        <loc>https://mantaroh.org/pages/index.html</loc>
        <changefreq>daily</changefreq>
        <priority>0.7</priority>
    </url>
</urlset>
```

### Ask using sitemap generation command prompt:

```
? Name of your project test
? Use Spearly CMS Yes
? Enter your Spearly CMS API KEY abcdef
? Choose template type basic
? Generate Sitemap? Yes
? Enter your hosting URL (Example: https://foobar.netlify.app/) https://mantaroh.org/
```