### PR TITLE
Fix the generated package name of package.json

### DIFF
--- a/packages/spear-cli/src/create.ts
+++ b/packages/spear-cli/src/create.ts
@@ -140,7 +140,7 @@ async function createBoilerplate() {
   packageJson.name = settings.answers.projectName
   const cliVersion = await getSpearCliVersion()
   if (cliVersion) {
-    packageJson.dependencies["spear-cli"] = `^${cliVersion}`
+    packageJson.dependencies["@spearly/spear-cli"] = `^${cliVersion}`
   }
   fs.writeFileSync(`${basePath}/package.json`, JSON.stringify(packageJson, null, 2))
 
@@ -168,7 +168,7 @@ function getSpearCliVersion() {
     const options = {
       hostname: "registry.npmjs.org",
       port: 443,
-      path: "/spear-cli",
+      path: "/@spearly/spear-cli",
       method: "GET",
     }
 

--- a/packages/spear-cli/src/templates/basic/package.json
+++ b/packages/spear-cli/src/templates/basic/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {},
   "dependencies": {
     "html-minifier-terser": "^7.0.0-beta.0",
-    "node-html-parser": "^5.3.3",
-    "@spearly/spear-cli": ""
+    "node-html-parser": "^5.3.3"
   }
 }

--- a/packages/spear-cli/src/templates/empty/package.json
+++ b/packages/spear-cli/src/templates/empty/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {},
   "dependencies": {
     "html-minifier-terser": "^7.0.0-beta.0",
-    "node-html-parser": "^5.3.3",
-    "@spearly/spear-cli": ""
+    "node-html-parser": "^5.3.3"
   }
 }


### PR DESCRIPTION
## What is this?

The package name of created package.json is previous package name. Correctly, it's `@spearly/spear-cli`.
So this pr will fix it.

Wrong generated package.json
```
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "license": "ISC",
  "private": true,
  "scripts": {
    "dev": "spear watch",
    "build": "spear build"
  },
  "devDependencies": {},
  "dependencies": {
    "html-minifier-terser": "^7.0.0-beta.0",
    "node-html-parser": "^5.3.3",
    "@spearly/spear-cli": "^1.1.3",
    "spear-cli": "^1.0.13"
  }
}
```
