### PR TITLE
Fix: Regenerate HTML Element node since HTML Element node might be released.

### DIFF
--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -78,8 +78,11 @@ async function parseElements(state: State, nodes: Element[]) {
       continue
     }
     if (component) {
-      // console.log("  append component", component.node.outerHTML)
-      component.node.childNodes.forEach((child) => res.appendChild(child))
+      // Regenerate node since node-html-parser's HTMLElement doesn't have deep copy.
+      // If we consumed this element once, this HTML node might release on memory.
+      const minified = await minify(component.rawData, { collapseWhitespace: true })
+      const node = parse(minified) as Element
+      node.childNodes.forEach((child) => res.appendChild(child.clone()))
       continue
     }
 


### PR DESCRIPTION
## What is this?

If we specify the components from above two pages, one of this page might NOT be inserted component.  
Because node-html-parser package doesn't have deep copy of HTML node object. So if we consumed html element node once, this element node might be released from memory.

## Changes:

- Regenerate HTML Element node when inserting component.