### PR TITLE
Fix build error.

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -10,10 +10,8 @@
   "scripts": {
     "tsc": "tsc",
     "clean": "rm -rf dist",
-    "build": "npm run clean && tsc --build src && npm run copy-files",
-    "dev": "nodemon --watch \".\" -e js,ts --exec \"npm run build\"",
-    "copy-files": "npm-run-all copy-files:*",
-    "copy-files:templates": "mkdir -p dist/templates && cp -R src/templates/* dist/templates/"
+    "build": "npm run clean && tsc --build src",
+    "dev": "nodemon --watch \".\" -e js,ts --exec \"npm run build\""
   },
   "bin": {
     "spear": "./dist/index.js"


### PR DESCRIPTION
## Changes:

- Remove copy task from building command. Because, `spear-cli` doesn't need this task since we move the creating project into `create-spear`.
