### PR TITLE
Fix generated HTML to use the parent element.

### DIFF
--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -89,7 +89,8 @@ async function parseElements(state: State, nodes: Element[]) {
     // Inject CMS loop
     if (!isTextNode && node.getAttribute("cms-loop") !== undefined) {
       const contentType = node.getAttribute("cms-content-type")
-      const generatedStr = await jsGenerator.generateList(node.innerHTML, contentType)
+      node.removeAttribute("cms-content-type")
+      const generatedStr = await jsGenerator.generateList(node.outerHTML, contentType)
       const generatedNode = parse(generatedStr) as Element
       res.appendChild(generatedNode)
       continue
@@ -104,7 +105,9 @@ async function parseElements(state: State, nodes: Element[]) {
     ) {
       const contentType = node.getAttribute("cms-content-type")
       const contentId   = node.getAttribute("cms-content")
-      const generatedStr = await jsGenerator.generateContent(node.innerHTML, contentType, contentId)
+      node.removeAttribute("cms-content-type")
+      node.removeAttribute("cms-content")
+      const generatedStr = await jsGenerator.generateContent(node.outerHTML, contentType, contentId)
       const generatedNode = parse(generatedStr) as Element
       res.appendChild(generatedNode)
       continue

--- a/packages/spear-cli/src/templates/index.html
+++ b/packages/spear-cli/src/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{projectName}}</title>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
### Changes

This PR fix the following feedback issue:

I got the feedback for spear user
` Content list has only specified element's child. Expected result is containing the specified element.`

They specified the following HTML :

```html
<div cms-loop cms-content-type="faq">
    <p class="question">{%= faq_q %}</p>
    <div class="answer">{%= faq_a %}</div>
</div>
```

Rendered HTML is:

```html
<div>
        <p class="question">faq_q#1</p>
        <div class="answer">faq_a#1</div>
        <p class="question">faq_q#2</p>
        <div class="answer">faq_a#2</div>
...
        <p class="question">faq_q#n</p>
        <div class="answer">faq_a#n</div>
</div>
```

Expected Result is bellow:

```html
<div>
        <p class="question">faq_q#1</p>
        <div class="answer">faq_a#1</div>
</div>
<div>
        <p class="question">faq_q#2</p>
        <div class="answer">faq_a#2</div>
</div>
...
<div>
        <p class="question">faq_q#3</p>
        <div class="answer">faq_a#3</div>
</div>
```

