### PR TITLE
:memo: add editor information

### DIFF
--- a/packages/spear-cli/README.md
+++ b/packages/spear-cli/README.md
@@ -193,21 +193,18 @@ module.exports = {
 };
 ```
 
-## About Editor
+## Editor settings
 
-Spear does not choose an editor.
-However, the following settings will allow you to develop comfortably.
+Spear is a editor free tool.
+However, you can use the following settings to have a better experience when coding in your favorite editor.
 
 ### Visual Studio Code
 
-Please use `vscodeSettings.json` generated when the project is created.
+A default settings is created at `.vscode/settings.json` for better highlighting of the code, specially `.spear` files.
 
-### JetBrains(IntelliJ, WebStorm, PhpStorm and so on.)
+### JetBrains(IntelliJ, WebStorm, PhpStorm, etc)
 
-- Until the IntelliJ Plugin is ready, you will need to configure your own settings.
-- Follow the official documentation and configure it to recognize `.spear` as `.html`.
-
-[Configure associations between filename patterns and file types](https://www.jetbrains.com/help/idea/creating-and-registering-file-types.html#configure-associations-between-filename-patterns-and-file-types)
+While IntelliJ Plugin is under construction, there is a workaround for the editor to highlight `.spear` files at  [Configure associations between filename patterns and file types](https://www.jetbrains.com/help/idea/creating-and-registering-file-types.html#configure-associations-between-filename-patterns-and-file-types)
 
 ## Contributing
 

--- a/packages/spear-cli/README.md
+++ b/packages/spear-cli/README.md
@@ -193,6 +193,21 @@ module.exports = {
 };
 ```
 
+## About Editor
+
+Spear does not choose an editor.
+However, the following settings will allow you to develop comfortably.
+
+### Visual Studio Code
+
+Please use `vscodeSettings.json` generated when the project is created.
+
+### JetBrains(IntelliJ, WebStorm, PhpStorm and so on.)
+
+- Until the IntelliJ Plugin is ready, you will need to configure your own settings.
+- Follow the official documentation and configure it to recognize `.spear` as `.html`.
+
+[Configure associations between filename patterns and file types](https://www.jetbrains.com/help/idea/creating-and-registering-file-types.html#configure-associations-between-filename-patterns-and-file-types)
 
 ## Contributing
 

--- a/packages/spear-cli/README_ja.md
+++ b/packages/spear-cli/README_ja.md
@@ -204,7 +204,7 @@ Spear はエディタを選びません。
 
 ### Visual Studio Code
 
- プロジェクト作成時に生成される `vscodeSettings.json` を利用してください。
+ プロジェクト作成時に生成される `.vscode/settings.json` を利用してください。
 
 ### JetBrains(IntelliJ, WebStorm, PhpStorm 等)
 

--- a/packages/spear-cli/README_ja.md
+++ b/packages/spear-cli/README_ja.md
@@ -197,6 +197,23 @@ module.exports = {
 };
 ```
 
+## エディタについて
+
+Spear はエディタを選びません。
+ただし、以下の設定をすることでより快適な開発が行えます。
+
+### Visual Studio Code
+
+ プロジェクト作成時に生成される `vscodeSettings.json` を利用してください。
+
+### JetBrains(IntelliJ, WebStorm, PhpStorm 等)
+
+- IntelliJ の Plugin ができるまでは、独自の設定が必要です。
+- 公式ドキュメントに沿って、 `.spear` を `.html` として認識するように設定してください。
+
+[ファイル名パターンとファイルタイプ間の関連付けを構成する](https://pleiades.io/help/idea/creating-and-registering-file-types.html#configure-associations-between-filename-patterns-and-file-types)
+
+
 ## 貢献
 
 このプロジェクトへ貢献する場合は、[CONTRIBUTING.md](../../CONTRIBUTING.md) をご覧ください！


### PR DESCRIPTION
## Overview

- Update README  in relation to this issue #72. 
- It's too difficult for me to manage the extension with `.idea`, so I am creating a document.
- This is a temporary PR until the IntelliJ plugin is available( #73 ).