### PR TITLE
Fix: support over two level depth

### DIFF
--- a/packages/create-spear/package-lock.json
+++ b/packages/create-spear/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-spear",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-spear",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",

--- a/packages/create-spear/package.json
+++ b/packages/create-spear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-spear",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Create spear project",
   "author": "spear",
   "type": "module",

--- a/packages/create-spear/src/templates/basic/.gitignore
+++ b/packages/create-spear/src/templates/basic/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/create-spear/src/templates/basic/src/index.html
+++ b/packages/create-spear/src/templates/basic/src/index.html
@@ -8,51 +8,53 @@
   <title>{{projectName}}</title>
   <link rel="stylesheet" href="./assets/main.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/vs.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>  
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
 </head>
-  <body>
-    <header>
-      <img src="./images/logo.png">
-      <div class="spear-description">
-        <p><span>Welcome spear-cli</span> powered by Spearly CMS🚀</p>
+
+<body>
+  <header>
+    <img src="./images/logo.png">
+    <div class="spear-description">
+      <p><span>Welcome spear-cli</span> powered by Spearly CMS🚀</p>
+    </div>
+  </header>
+  <main class="container">
+    <section class="container__description margined-section">
+      <p>Spearly CMS is headless CMS easy to embed.</p>
+      <p>spear-cli is the magic tools make site more easy🧙</p>
+    </section>
+    <section class="container__usage margined-section">
+      <div class="container__spear-code">
+        <div>
+          <p>You can create component easily, You just create component spear file into components like follow:</p>
+        </div>
+        <pre><code class="html">
+            &lt;div&gt;
+              &lt;h1&gt;Hello first component&lt;/h1&gt;
+            &lt;/div&gt;
+          </code></pre>
       </div>
-    </header>
-    <main class="container">
-      <section class="container__description margined-section">
-        <p>Spearly CMS is headless CMS easy to embed.</p>
-        <p>spear-cli is the magic tools make site more easy🧙</p>
-      </section>
-      <section class="container__usage margined-section">
-        <div class="container__spear-code">
-          <div>
-            <p>You can create component easily, You just create component spear file into components like follow:</p>
-          </div>
-          <pre><code class="html">
-&lt;div&gt;
-  &lt;h1&gt;Hello first component&lt;/h1&gt;
-&lt;/div&gt;
-          </code></pre>
+    </section>
+    <section class="container__usage margined-section">
+      <div class="container__spear-code">
+        <div>
+          <p>Then you insert this component like html tags:</p>
         </div>
-      </section>
-      <section class="container__usage margined-section">
-        <div class="container__spear-code">
-          <div>
-            <p>Then you insert this component like html tags:</p>
-          </div>
-          <pre><code class="html">
-&lt;section&gt;
-  &lt;first-component&gt;&lt;/first-component&gt;
-&lt;/section&gt;
+        <pre><code class="html">
+          &lt;section&gt;
+            &lt;first-component&gt;&lt;/first-component&gt;
+          &lt;/section&gt;
           </code></pre>
-        </div>
-      </section>
-      <section class="container__usage margined-section">
-        <p>You can check generated file from components and panges/index.spear</p>
-        <p>
-          <a href="./pages/index.html">Generated index here</a>
-        </p>
-      </section>
-    </main>
-    <script>hljs.initHighlightingOnLoad();</script>
-  </body>
+      </div>
+    </section>
+    <section class="container__usage margined-section">
+      <p>You can check generated file from components and panges/index.spear</p>
+      <p>
+        <a href="./pages/index.html">Generated index here</a>
+      </p>
+    </section>
+  </main>
+  <script>hljs.initHighlightingOnLoad();</script>
+</body>
+
 </html>

--- a/packages/create-spear/src/templates/empty/.gitignore
+++ b/packages/create-spear/src/templates/empty/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "license": "ISC",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.4",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -178,7 +178,7 @@ async function parsePages(state: State, dirPath: string, relatePath = "") {
     const isDir = fs.existsSync(filePath) && fs.lstatSync(filePath).isDirectory()
 
     if (isDir) {
-      await parsePages(state, filePath, file)
+      await parsePages(state, filePath, relatePath + (relatePath !== "" ? '/' : '') + file)
     } else if (needSASSBuild(ext)) {
       const result = sass.compile(filePath)
       state.out.assetsFiles.push({ filePath: `${relatePath}/${fname}.css`, rawData: Buffer.from(result.css) })


### PR DESCRIPTION
### Changes

This PR has four changes:

1. Support structures which has over two level depth directories:(#81)

Previous version mis-convert the over two level depth directory structure.
Change file is `packages/spear-cli/src/magic.ts`.

2. Add `.gitignore` file into template project (#79)

Created project doesn't have a `.gitignore` file, so there are too many change files. This PR add the `.gitignore`.

3. Template's formatting (#76)

Generated basic template html doesn't formatted. This PR will fix it by using pritter.

4. Version up

This PR will version up `create-spear` and `spear-cli`.