### PR TITLE
Support mjs file

### DIFF
--- a/packages/create-spear/src/create.ts
+++ b/packages/create-spear/src/create.ts
@@ -155,8 +155,8 @@ async function createBoilerplate() {
   settingsFile.siteURL = settings.answers.siteURL
   if (Object.keys(settingsFile).length) {
     fs.writeFileSync(
-      `${basePath}/spear.config.js`,
-      `module.exports = ${JSON.stringify(settingsFile, null, 2)};`
+      `${basePath}/spear.config.mjs`,
+      `export default ${JSON.stringify(settingsFile, null, 2)};`
     )
   }
 

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -410,7 +410,7 @@ function loadFile(filePath: string) {
       if (files.length > 0) {
         const ext = path.extname(files[0])
 
-        if (ext === ".js") {
+        if (ext === ".js" || ext === ".mjs") {
           const data = await import(
             files[0],
             files[0].indexOf("json") > -1 ? { assert: { type: "json" } } : undefined
@@ -430,7 +430,7 @@ function loadFile(filePath: string) {
 }
 
 async function loadSettingsFromFile() {
-  const data = await loadFile(`${dirname}/${Settings.settingsFile}.?(js|json)`)
+  const data = await loadFile(`${dirname}/${Settings.settingsFile}.?(mjs|js|json)`)
   if (data) {
     Object.keys(data).forEach((k) => {
       Settings[k] = data[k]


### PR DESCRIPTION
### What is this?

This PR make spear-cli to support `mjs` file.

### Why mjs?

Current configuration file is classical JavaScript file (`.js`). So if we want to add the function value settings into config file, user should use `require` syntax when they want to use external library.

e.g.,
```
const { convert } = require('html-to-text');
module.exports = {
  "converter": convert
}
```

This is not modern...  

We should support module javascript (`.mjs`) file, then we allow the following specification on config files.

```
import { convert } from 'http-to-text';
default exports {
  "converter": convert,
}
```
