### PR TITLE
Remove collecting inline script and inline stylesheet.

### DIFF
--- a/packages/spear-cli/src/interfaces/magicInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/magicInterfaces.ts
@@ -21,8 +21,6 @@ export interface State {
   body: Element
   globalProps: { [key: string]: string }
   out: {
-    css: string[],
-    script: string[],
     assetsFiles: AssetFile[]
   }
 }


### PR DESCRIPTION
### What is this?

This PR remove the mechanism of collecting inline-script and inline-stylesheet since this mechanism is unnecessary.

For example, if we have the following code:

index.html:
```html
<html>
 <head>
   <title>test spear</title>
 </head>
<body>
<p>this is sample</p>
<script>
  console.log("Hello Spear");
</script>
</body>
```

spear-cli will generate the following two files:

- index.html:
```html
<html>
 <head>
   <title>test spear</title>
   <script src="./script.js"></script>
 </head>
 <head>
   <title>test spear</title>
 </head>
<body>
<p>this is sample</p>
</body>
```

- script.js
```javascript
console.log("Hello Spear");
```

This generated script will import from all of pages, at the moment. As result of it, generated HTML has unrelated script.

This mechanism might prepare for scoped script and scoped style, however we don't have such feature yet. So this PR will remove this mechanism from conversion.