### PR TITLE
🐛  Remove cms-loop attribute when finding it.

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "ISC",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.4",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -76,6 +76,7 @@ async function parseElements(state: State, nodes: Element[]) {
     // Inject CMS loop
     if (!isTextNode && node.getAttribute("cms-loop") !== undefined) {
       const contentType = node.getAttribute("cms-content-type")
+      node.removeAttribute("cms-loop")
       node.removeAttribute("cms-content-type")
       const generatedStr = await jsGenerator.generateList(node.outerHTML, contentType)
       const generatedNode = parse(generatedStr) as Element


### PR DESCRIPTION
### Changes:

- Remove cms-loop attribute when traversing and find it.
- Version up spear-cli to 1.1.10
