### PR TITLE
Address the npm badge correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Spear project has the following packages:
 | Packages | Status | Details | README Link |
 |---|---|---|---|
 | [`spear-cli`](./packages/spear-cli/) | [![npm version](https://badge.fury.io/js/spear-cli.svg)](https://badge.fury.io/js/spear-cli) | SSG CLI | [README](./packages/spear-cli/README.md) |
+| [`create-spear`](./packages/create-spear/) | [![npm version](https://badge.fury.io/js/create-spear.svg)](https://badge.fury.io/js/create-spear) | Spear Project creation tool | [README](./packages/create-spear/README.md) |
 | [`cms-js-core`](./packages/spearly-cms-js-core/) | Public | Spearly contents converter library. | [README](./packages/spearly-cms-js-core/README.md) |
 | `spearly-flutter` | In Planning | The library which Embedding CMS Content into Flutter | - |
 | `spearly-svelte` | In Planning | The library which embedding CMS Content into Svelte Kit | - |

--- a/README_ja.md
+++ b/README_ja.md
@@ -15,6 +15,7 @@ Spear には以下のパッケージがあります。
 | Packages | Status | Details | README Link |
 |---|---|---|---|
 | [`spear-cli`](./packages/spear-cli/) | [![npm version](https://badge.fury.io/js/spear-cli.svg)](https://badge.fury.io/js/spear-cli) | SSG 本体 | [README](./packages/spear-cli/README_ja.md) |
+| [`create-spear`](./packages/create-spear/) | [![npm version](https://badge.fury.io/js/create-spear.svg)](https://badge.fury.io/js/create-spear) | Spear プロジェクト作成ツール | [README](./packages/create-spear/README_ja.md) |
 | [`cms-js-core`](./packages/spearly-cms-js-core/) | 公開中 | Spearly のコンテンツ埋め込みコンバーターライブラリ | [README](./packages/spearly-cms-js-core/README_ja.md) |
 | `spearly-flutter` | 計画中 | Flutter へ CMS コンテンツを埋め込めるライブラリ | - |
 | `spearly-svelte` | 計画中 | Svelte Kit へ CMS コンテンツを埋め込めるライブラリ | - |

--- a/packages/spear-cli/README.md
+++ b/packages/spear-cli/README.md
@@ -2,7 +2,7 @@
 
 # spear-cli
 
-[![npm version](https://badge.fury.io/js/spear-cli.svg)](https://badge.fury.io/js/spear-cli)
+[![npm version](https://badge.fury.io/js/@spearly%2Fspear-cli.svg)](https://badge.fury.io/js/@spearly%2Fspear-cli)
 
 This is SSG(Static Site Generator) for Spearly.  
 

--- a/packages/spear-cli/README_ja.md
+++ b/packages/spear-cli/README_ja.md
@@ -2,7 +2,7 @@
 
 # spear-cli
 
-[![npm version](https://badge.fury.io/js/spear-cli.svg)](https://badge.fury.io/js/spear-cli)
+[![npm version](https://badge.fury.io/js/@spearly%2Fspear-cli.svg)](https://badge.fury.io/js/@spearly%2Fspear-cli)
 
 `spear-cli` は Spearly 向けの静的サイトジェネレーターです (SSG) 
 


### PR DESCRIPTION
### Changes:

This PR will address the following README issue.

- Add `create-spear` package into top README page.
- Change spear-cli badge repo name.