### PR TITLE
Support plugin Hook API

### DIFF
--- a/packages/spear-cli/src/interfaces/HookCallback.ts
+++ b/packages/spear-cli/src/interfaces/HookCallback.ts
@@ -1,0 +1,76 @@
+import { DefaultSettings } from "./SettingsInterfaces"
+import { HTMLElement } from "node-html-parser"
+
+export type SpearSettings = DefaultSettings
+
+export type Element = HTMLElement & { props: { [key: string]: string } }
+
+export interface Component {
+  fname: string
+  tagName: string
+  rawData?: string
+  node: Element
+  props: { [key: string]: string }
+}
+
+export interface AssetFile {
+  filePath: string
+  rawData?: Buffer
+}
+
+export interface SpearState {
+  pagesList: Component[]
+  componentsList: Component[]
+  body: Element
+  globalProps: { [key: string]: string }
+  out: {
+    assetsFiles: AssetFile[]
+  }
+}
+
+/**
+ * Call after configuration has finished.
+ * If you change the original settings value, you need to return 
+ * SpearSetting object in this function.
+ */
+export interface ConfigurationHookFunction {
+    (setting: SpearSettings): Promise<SpearSettings | null>
+}
+
+/**
+ * Call before starting build process.
+ * If you change the original state value, you need to return
+ * SpearState object in this function.
+ */
+export interface BeforeBuildHookFunction {
+    (state: SpearState): Promise<SpearState | null>
+}
+
+/**
+ * Call after finishing build process.
+ * If you change the original state value, you need to return
+ * SpearState object in this function.
+ */
+export interface AfterBuildHookFunction {
+    (state: SpearState): Promise<SpearState | null>
+}
+
+/**
+ * Call before starting bundle process.
+ * If you change the original state value, you need to return
+ * SpearState object in this function.
+ */
+export interface BundleHookFunction {
+    (state: SpearState): Promise<SpearState | null>
+}
+
+/**
+ * Hook API structure.
+ * You can specify this object into spear.config.mjs.
+ */
+export interface HookApi {
+    configuration?: ConfigurationHookFunction,
+    beforeBuild?: BeforeBuildHookFunction,
+    afterBuild? : AfterBuildHookFunction,
+    bundle? : BundleHookFunction,
+}

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -1,3 +1,5 @@
+import { HookApi } from "./HookCallback"
+
 export interface DefaultSettings {
   projectName?: string
   settingsFile?: string
@@ -13,4 +15,5 @@ export interface DefaultSettings {
   apiDomain: string,
   generateSitemap: boolean,
   siteURL: string,
+  plugins: HookApi[]
 }


### PR DESCRIPTION
## What is this?

This feature is supporting plugin Hook API(#70).  
Several feature like i18n use this plugin, so we need to implement this feature before i18n / seo.

## How to use it?

We can specify plugin feature into `spear.config.js` or `spear.config.mjs` :


```
const  samplePlugin = {
   configuration: function(settings) { console.log(settings); },
   beforeBuild: function(state) { console.log(state); },
   afterBuild: function(state) { console.log(state); },
   bundle: function(state) { console.log(state); },
}

export.module = {
  "plugins": [
    samplePlugin,
  ]
}
```

An above sample show parameter in each hook handler.