### PR TITLE
Support SEO tag(spear-seo)

### DIFF
--- a/packages/spear-cli/src/interfaces/HookCallback.ts
+++ b/packages/spear-cli/src/interfaces/HookCallback.ts
@@ -1,7 +1,8 @@
 import { DefaultSettings } from "./SettingsInterfaces"
 import { HTMLElement } from "node-html-parser"
 
-export type SpearSettings = DefaultSettings
+export interface SpearSettings extends DefaultSettings {
+}
 
 export type Element = HTMLElement & { props: { [key: string]: string } }
 

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -15,5 +15,6 @@ export interface DefaultSettings {
   apiDomain: string,
   generateSitemap: boolean,
   siteURL: string,
+  rootDir: string,
   plugins: HookApi[]
 }

--- a/packages/spear-cli/src/plugins/spear-seo.ts
+++ b/packages/spear-cli/src/plugins/spear-seo.ts
@@ -1,0 +1,102 @@
+import { parse } from "node-html-parser"
+import { loadFile } from "../util.js"
+import { Component, Element, HookApi, SpearSettings, SpearState } from "../interfaces/HookCallback"
+
+let globalSettings: Map<string, string>
+
+// This plugin will replace `spear-seo` tag.
+// SettingsFile:
+//   JavaScript Object files which has key and value like following.
+//   export default {
+//     title: "Blog site.",
+//   }
+export function spearSEO(settingsFile?: string): HookApi {
+    // Use configuration and afterBuild hook for generating SEO.
+    return {
+        configuration: async function(settings: SpearSettings) {
+            globalSettings = new Map<string, string>()
+            if (settingsFile !== "") {
+                try {
+                    const settingFileContent = await loadFile(`${settings.rootDir}/${settingsFile}`)
+                    if (settingFileContent) {
+                        Object.keys(settingFileContent).forEach((k) => {
+                            globalSettings.set(k, settingFileContent[k])
+                        })
+                    }
+                } catch (e) {
+                    console.log("  [Plugins] Reading settings file failure:")
+                    console.error(e)
+                    throw e
+                }
+            }
+            return null
+        },
+        beforeBuild: undefined,
+        afterBuild: generateSEOBeforeBundle,
+        bundle: undefined,
+    }
+}
+
+async function generateSEOBeforeBundle(state: SpearState): Promise<SpearState> {
+    console.log('  [Plugins] Spear SEO Generation:')
+    const generatedState = Object.assign({}, state) as SpearState
+    const pageList = [] as Component[]
+    for (const page of generatedState.pagesList) {
+        console.log("  [Plugins] Traverse SEO Tag on :" + page.fname)
+        // If target Node doesn't have <html> element,
+        // wrap it by empty html.
+        let indexNode: Element
+        if (!page.node.innerHTML.includes("</html>")) {
+            indexNode = parse(`<!DOCTYPE html><html lang=en><head><meta charset=UTF-8><meta content="IE=edge"http-equiv=X-UA-Compatible><meta content="width=device-width,initial-scale=1"name=viewport></head><body></body></html>`) as Element
+            const body = indexNode.querySelector("body")
+            if (!body) {
+                throw new Error("SEO Plugin: Internal Error. Fail converting the empty html.")
+            }
+            body.appendChild(page.node)
+        } else {
+            indexNode = page.node
+        }
+        
+        // Replace Global SEO Setting
+        let htmlStr = indexNode.outerHTML as string
+        globalSettings.forEach((val, key) => {
+            htmlStr = htmlStr.split(`{%= #seo_${key} %}`).join(val)
+        });
+        indexNode = parse(htmlStr) as Element
+
+        // Replace each SEO Tag.
+        // Support one spear-seo tag in one HTML file.
+        const spearSEOTag = indexNode.querySelector("spear-seo")
+        if (spearSEOTag) {
+            console.log("  [Plugins] separ-seo found.")
+            const headerTag = indexNode.querySelector("head")
+            Object.keys(spearSEOTag.attributes).forEach((k) => {
+                if (k === "title") {
+                    const titleTag = parse(`<title>${spearSEOTag.attributes[k]}</title>`)
+                    headerTag.appendChild(titleTag)
+                } else if (k.startsWith("meta-")) {
+                    const metaName = k.replace("meta-", "")
+                    const metaValue = spearSEOTag.attributes[k]
+                    const metaTag = parse(`<meta name="${metaName}" content="${metaValue}">`)
+                    headerTag.appendChild(metaTag)
+                } else if (k.startsWith("link-")) {
+                    const linkRel = k.replace("link-", "")
+                    const linkHref = spearSEOTag.attributes[k]
+                    const linkTag = parse(`<link rel="${linkRel}" href="${linkHref}">`)
+                    headerTag.appendChild(linkTag)
+                }
+            })
+            spearSEOTag.remove()
+        }
+        pageList.push({
+            fname: page.fname,
+            tagName: page.tagName,
+            rawData: indexNode.outerHTML,
+            node: indexNode,
+            props: page.props,
+        })
+    }
+    generatedState.pagesList = pageList
+
+    return generatedState
+}

--- a/packages/spear-cli/src/util.ts
+++ b/packages/spear-cli/src/util.ts
@@ -1,0 +1,84 @@
+import glob from "glob"
+import fs from "fs"
+import path from "path"
+import { parse } from "node-html-parser"
+import { AssetFile, Component, Element, State } from "./interfaces/magicInterfaces"
+import { DefaultSettings } from "./interfaces/SettingsInterfaces"
+
+function componentsDeepCopy(components: Component[]): Component[] {
+    const ret = [] as Component[]
+    components.forEach(component => {
+        ret.push({
+            fname: component.fname,
+            tagName: component.tagName,
+            rawData: component.rawData,
+            node: parse(component.node.outerHTML) as Element,
+            props: JSON.parse(JSON.stringify(component.props)),
+        })
+    })
+    return ret
+}
+
+function bufferDeepCopy(buffer: Buffer): Buffer {
+    if (!buffer) return null
+    const newBuffer = new Buffer(buffer.length)
+    buffer.copy(newBuffer)
+    return buffer
+}
+
+function assetsDeepCopy(assets: AssetFile[]): AssetFile[] {
+    const ret = [] as AssetFile[]
+    assets.forEach(assetFile => {
+        ret.push({
+            filePath: assetFile.filePath,
+            rawData: bufferDeepCopy(assetFile.rawData),
+        })
+    })
+    return ret
+}
+
+export function stateDeepCopy(state: State): State {
+    return {
+        pagesList: componentsDeepCopy(state.pagesList),
+        componentsList: componentsDeepCopy(state.componentsList),
+        body: parse(state.body.outerHTML) as Element,
+        globalProps: JSON.parse(JSON.stringify(state.globalProps)),
+        out: {
+            assetsFiles: assetsDeepCopy(state.out.assetsFiles)
+        }
+    }
+}
+
+export function defaultSettingDeepCopy(config: DefaultSettings): DefaultSettings {
+    return JSON.parse(JSON.stringify(config))
+}
+
+export function loadFile(filePath: string) {
+    return new Promise((resolve, reject) => {
+      glob(filePath, null, async (er, files) => {
+        if (er) {
+          reject(er)
+          return
+        }
+  
+        if (files.length > 0) {
+          const ext = path.extname(files[0])
+  
+          if (ext === ".js" || ext === ".mjs") {
+            const data = await import(
+              files[0],
+              files[0].indexOf("json") > -1 ? { assert: { type: "json" } } : undefined
+            )
+            resolve(data.default)
+          } else if (ext === ".json") {
+            const data = fs.readFileSync(files[0], "utf8")
+            resolve(JSON.parse(data))
+          } else {
+            resolve(fs.readFileSync(files[0], "utf8"))
+          }
+        } else {
+          resolve(null)
+        }
+      })
+    })
+  }


### PR DESCRIPTION
### What is this?

This PR will make spear to support SEO tag(#61).

1. HookAPI changes:
- Move `loadFile` function to `util.ts`.
- Call HookAPI when specified each function. (i.e., If target hook API is undefined, spear doesn't call it)
- Copy result of hook api for manipulating the spear behavior from plugins.

2. SEO Tag:
- Add `spear-seo` plugins into plugins directory.
- Support Global SEO Settings as file. (`spearSEO` function parameter)

### How do we use this feature?

You can add `spearSEO` function to plugin object `spear.config.mjs`:

```javascript
import { spearSEO } from "@spearly/spear-cli/dist/plugins/spear-seo.js"

export default {
  "projectName": "test",
  "generateSitemap": false,
  "plugins": [
    spearSEO("./seo.config.mjs"),
  ]
}
```

The 1st parameter of `spearSEO` is configuration file. This configuration file is global SEO settings. 

seo.config.mjs
```javascript
export default {
  "title": "Common title",
  "url": "https://foobar.com",
}
```

you can specify `spear-seo` tag into each page(html/htm/spear).

```html
<div>
  <spear-seo
    title="{%= #seo_title %}"
    meta-description="meta description"
  ></spear-seo>
</div>
```

In the above example, `{%= #seo_title %}` is referred from global settings. If you specify the unique title in this page, you should write as `title="unique title"`.

---

### これは何？

この PR は SEO タグをサポートするようにします (#61)

1. HookAPI の変更:
- `loadFile` 関数を `util.ts` へ移動
- HookAPI が指定されているときだけ実行するように変更(つまり、hookAPI が undefined の時は、Spear で実行しない)
- プラグインが Spear の動きを変更できるように HookAPI の戻り値をコピーする

3. SEO タグ:
- `spear-seo` プラグインをプラグインディレクトリに追加
- グローバル SEO 設定をファイルとしてサポート (`spearSEO` 関数のパラメータで指定)

### SEO タグ機能を使うには？

`spearSEO` 関数を `spear.config.mjs` のプラグインオブジェクトに指定します。

```javascript
import { spearSEO } from "@spearly/spear-cli/dist/plugins/spear-seo.js"

export default {
  "projectName": "test",
  "generateSitemap": false,
  "plugins": [
    spearSEO("./seo.config.mjs"),
  ]
}
```

この第一引数は、設定ファイルです。この設定はグローバルな SEO 設定です。

seo.config.mjs
```javascript
export default {
  "title": "Common title",
  "url": "https://foobar.com",
}
```

これで各ページ(html/htm/spear) に `spear-seo` タグを指定できます。

```html
<div>
  <spear-seo
    title="{%= #seo_title %}"
    meta-description="meta description"
  ></spear-seo>
</div>
```

上記サンプルの `{%= #seo_title %}` はグローバル設定から取得します。もし個別に設定したい場合は、`title="個別のタイトル"` のように指定します。