### PR TITLE
:adhesive_bandage: fix to be able to display metadata for OGP

### DIFF
--- a/packages/spear-cli/src/plugins/spear-seo.ts
+++ b/packages/spear-cli/src/plugins/spear-seo.ts
@@ -56,7 +56,7 @@ async function generateSEOBeforeBundle(state: SpearState): Promise<SpearState> {
         } else {
             indexNode = page.node
         }
-        
+
         // Replace Global SEO Setting
         let htmlStr = indexNode.outerHTML as string
         globalSettings.forEach((val, key) => {
@@ -77,7 +77,10 @@ async function generateSEOBeforeBundle(state: SpearState): Promise<SpearState> {
                 } else if (k.startsWith("meta-")) {
                     const metaName = k.replace("meta-", "")
                     const metaValue = spearSEOTag.attributes[k]
-                    const metaTag = parse(`<meta name="${metaName}" content="${metaValue}">`)
+                    let metaTag = parse(`<meta name="${metaName}" content="${metaValue}">`)
+                    if (metaName.includes('og:')) {
+                        metaTag = parse(`<meta property="${metaName}" content="${metaValue}">`)
+                    }
                     headerTag.appendChild(metaTag)
                 } else if (k.startsWith("link-")) {
                     const linkRel = k.replace("link-", "")


### PR DESCRIPTION
## Overview

:adhesive_bandage: fix to be able to display metadata for OGP

- https://github.com/unimal-jp/spear/issues/61#:~:text=twitter%3Acard%3D%22summary%22%0A/%3E-,Embed%20syntax,-In%20SEO%20tag

### Before spear-cli build

**index.spaer**

```html:index.spaer
<spear-seo
    title="title"
    meta-description="description"
    meta-og:title="title"
    meta-og:description="description"
></spear-seo>
```

### After spear-cli build

**index.html**

```html:index.html
<title>title</title>
<meta name="description" content="description">
<meta property="og:title" content="title" >
<meta property="og:description" content="description" >

```