### PR TITLE
Fix: localize function should consider the absolute path

### DIFF
--- a/packages/spear-cli/src/plugins/spear-i18n.ts
+++ b/packages/spear-cli/src/plugins/spear-i18n.ts
@@ -162,7 +162,7 @@ async function generateI18nBeforeBundle(state: SpearState): Promise<SpearState> 
                 matchLocalizeSyntax.forEach(m => {
                     const tempKey = m.match(/\(.*?\)/g)[0]
                     const url = tempKey.substr(2, tempKey.length - 4)
-                    const val = `${lang}${url}`
+                    const val = url.startsWith("/") ? `/${lang}${url}` : `${lang}${url}`
                     replacedLocalizeMap.set(m, val)
                 })
                 replacedLocalizeMap.forEach((v, k) => {


### PR DESCRIPTION
### What is this?

This PR will address the #116 issue. This issue is based on absolute path. Spear i18n's localize function is not considered the absolute path.

### How do this change fix it?

If URL start with `/` character, Spear treat it as absolute path. (This mean generate url start with `/`)