### PR TITLE
Address usage of spear on top README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,27 +24,12 @@ The Spear project has the following packages:
 
 ## SSG Usage
 
-1. Install the `spear-cli` package.
+1. Create project
 
-We provide the `spear-cli` package via NPM. So you can install this packages by using the following command:
-
-```bash
-# If you use the npm.
-$ npm install "@spearly/spear-cli" -g
-
-# If you use the yarn.
-$ yarn global add "@spearly/spear-cli"
-
-# If you use the pnpm.
-$ pnpm install "@spearly/spear-cli" -g
-```
-
-2. Create project
-
-You can create the project by using `spear `create` command to answer some questions.
+You can create the project by using `npm create spear@latest `create` command to answer some questions.
 
 ```bash
-$ spear create
+$ npm create spear@latest
 Namespace(port=undefined, action='create', projectName=undefined, src=undefined)
  ### Welcome to Spear CLI ###
 
@@ -67,7 +52,7 @@ Namespace(port=undefined, action='create', projectName=undefined, src=undefined)
       yarn build
 ```
 
-3. Install related packages and build the project
+2. Install related packages and build the project
 
 You can build the project for `build` task. (You can switch debug mode by using `dev` task as well)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -25,27 +25,12 @@ Spear には以下のパッケージがあります。
 
 ## SSG 利用方法
 
-1. `spear-cli` のインストール
+1. プロジェクトの作成
 
-`spear-cli` パッケージは NPM で配布されているので以下のコマンドでインストールが可能です。
-
-```bash
-# If you use the npm.
-$ npm install "@spearly/spear-cli" -g
-
-# If you use the yarn.
-$ yarn global add "@spearly/spear-cli"
-
-# If you use the pnpm.
-$ pnpm install "@spearly/spear-cli" -g
-```
-
-2. プロジェクトの作成
-
-`spear create` コマンドで質問に答えてプロジェクトを作成します。
+`npm create spear@latest` コマンドで質問に答えてプロジェクトを作成します。
 
 ```bash
-$ spear create
+$ npm create spear@latest
 Namespace(port=undefined, action='create', projectName=undefined, src=undefined)
  ### Welcome to Spear CLI ###
 
@@ -68,7 +53,7 @@ Namespace(port=undefined, action='create', projectName=undefined, src=undefined)
       yarn build
 ```
 
-3. 関連パッケージのインストールとプロジェクトのビルド
+2. 関連パッケージのインストールとプロジェクトのビルド
 
 `build` タスクを実行すればビルドできます。(`dev` タスクを実行すると開発サーバーが起動しデバッグモードになります。)
 


### PR DESCRIPTION
## What is this?

@masaki-ono gave me a feedback for README on top repository.

Now README of current top repository suggested installing `spear-cli` as local global package. However, we lauched the `create-spear` package, this package allow use spear without global install.

This PR will address this usage of README.

----

## これはなに？

@masaki-ono  さんからトップレポジトリのフィードバックをもらいました。

現在のトップレポジトリの README は、`spear-cli` パッケージをローカルのグローバルパッケージとしてインストールするように記載しています。しかし、私たちは `create-spear` パッケージをリリースしたことで、この操作は不要になっています。

この PR では、この README の利用方法部分を修正しています。