### PR TITLE
Fix parsing component and copy component

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.1.14",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.5",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "type": "module",
   "description": "",
   "preferGlobal": true,
@@ -30,7 +30,7 @@
     "url": "https://github.com/unimal-jp/spear/issues"
   },
   "dependencies": {
-    "@spearly/cms-js-core": "^1.0.6",
+    "@spearly/cms-js-core": "^1.0.7",
     "@types/live-server": "^1.2.1",
     "argparse": "^2.0.1",
     "chalk": "^5.2.0",

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -338,11 +338,10 @@ async function bundle(): Promise<boolean> {
   }
 
   // Run list again to parse children of the components
-  const componentsList = state.componentsList
-  state.componentsList = []
-  for (const component of componentsList) {
+  const componentsList = [] as Component[]
+  for (const component of state.componentsList) {
     const parsedNode = await parseElements(state, component.node.childNodes as Element[]) as Element[]
-    state.componentsList.push({
+    componentsList.push({
       "fname": component.fname,
       "rawData": parsedNode[0].outerHTML,
       "tagName": component.tagName,
@@ -350,6 +349,8 @@ async function bundle(): Promise<boolean> {
       "props": {}
     })
   }
+  state.componentsList = componentsList
+
   // Run list again to parse children of the pages
   for (const page of state.pagesList) {
     page.node.childNodes = await parseElements(state, page.node.childNodes as Element[])

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -97,10 +97,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@spearly/cms-js-core@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@spearly/cms-js-core/-/cms-js-core-1.0.6.tgz#076124fc354754d9667a18573b841c94b4336d2b"
-  integrity sha512-qto3xe7BV8W2/YJNQFig5P2YiTeb1gNB4TwLka0F+v+3CZSytVKcyBPoYs1wueyp6WKD4YbQRqJJLJ8NSlUPTg==
+"@spearly/cms-js-core@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@spearly/cms-js-core/-/cms-js-core-1.0.7.tgz#8abbbcea50b9717e4bcdbfc65eb671a4cff8443a"
+  integrity sha512-nx6kH3n1sWXbXaGaO801kzUvRlX9Ma9vpYjXrd6juWcswRKohfOf3WTSChxX+InIRizBIr18tC05Zqdn6x2DTg==
   dependencies:
     "@spearly/sdk-js" "^1.0.0"
     node-html-parser "^6.1.4"

--- a/packages/spearly-cms-js-core/package-lock.json
+++ b/packages/spearly-cms-js-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/cms-js-core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/cms-js-core",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@spearly/sdk-js": "^1.0.0",

--- a/packages/spearly-cms-js-core/package.json
+++ b/packages/spearly-cms-js-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spearly/cms-js-core",
   "private": false,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
### What is this?

This PR might fix the #133 .  
Previous Spear-cli inject component that founding only in parsing phase. This parsing process is based on alphabetical order.

So the component of alphabetical  last part might not be injected.

This patch will fix this issue.