### PR TITLE
Support tag looooop routing.

### DIFF
--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -42,7 +42,7 @@ export async function parseElements(state: State, nodes: Element[], jsGenerator:
     }
 
     // Inject CMS loop
-    if (!isTextNode && node.getAttribute("cms-loop") !== undefined) {
+    if (!isTextNode && node.getAttribute("cms-loop") !== undefined && node.getAttribute("cms-tag-loop") === undefined) {
       const contentType = node.getAttribute("cms-content-type");
       const apiOption = generateAPIOptionMap(node);
       removeCMSAttributes(node);
@@ -108,7 +108,8 @@ export async function generateAliasPagesFromPagesList(
       // Path has [tags].
       const tagAndAliasLoopElement = page.node.querySelector("[cms-item][cms-tag-loop]");
       const tagAndLoopElement = page.node.querySelector("[cms-loop][cms-tag-loop]");
-      const aliasLoopElement = page.node.querySelector("[cms-item]"); // In [alias].html, cms-item should be treat as cms-loop.
+      // In [alias].html, cms-item should be treat as cms-loop.
+      const aliasLoopElement = page.node.querySelector("[cms-item]");
       if (tagAndAliasLoopElement) {
         const tagFieldName = tagAndAliasLoopElement.getAttribute("cms-tag-loop");
         const contentType  = tagAndAliasLoopElement.getAttribute("cms-content-type");
@@ -164,7 +165,7 @@ export async function generateAliasPagesFromPagesList(
 
         if (page.fname.includes("[tags]")) {
           const apiOption = generateAPIOptionMap(tagAndLoopElement as Element);
-          removeCMSAttributes(tagAndAliasLoopElement as Element);
+          removeCMSAttributes(tagAndLoopElement as Element);
 
           const generatedLists = await jsGenerator.generateListGroupByTag(
             tagAndLoopElement.innerHTML,

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -104,9 +104,137 @@ export async function generateAliasPagesFromPagesList(
 ): Promise<Component[]> {
   const replacePagesList: Component[] = [];
   for (const page of state.pagesList) {
-    const targetElement = page.node.querySelector("[cms-item]");
-    if (page.fname.includes("[alias]") && targetElement) {
+    if (page.fname.includes("[tags]")) {
+      // Path has [tags].
+      const tagAndAliasLoopElement = page.node.querySelector("[cms-item][cms-tag-loop]");
+      const tagAndLoopElement = page.node.querySelector("[cms-loop][cms-tag-loop]");
+      const aliasLoopElement = page.node.querySelector("[cms-item]"); // In [alias].html, cms-item should be treat as cms-loop.
+      if (tagAndAliasLoopElement) {
+        const tagFieldName = tagAndAliasLoopElement.getAttribute("cms-tag-loop");
+        const contentType  = tagAndAliasLoopElement.getAttribute("cms-content-type");
+        if (!tagFieldName) throw new Error("You should specify the cms-tag-loop");
+        if (!contentType)  throw new Error("You should specify the cms-content-type");
+
+        if (page.fname.includes("[alias]")) {
+          const apiOption = generateAPIOptionMap(tagAndAliasLoopElement as Element);
+          removeCMSAttributes(tagAndAliasLoopElement as Element);
+          const generatedContents = await jsGenerator.generateEachContentFromList(
+            tagAndAliasLoopElement.innerHTML,
+            contentType,
+            apiOption,
+            tagFieldName
+          );
+          generatedContents.forEach(c => {
+            tagAndAliasLoopElement.innerHTML = c.generatedHtml;
+            const html = page.node.innerHTML.replace(
+              tagAndAliasLoopElement.innerHTML,
+              c.generatedHtml
+            );
+            if (c.tag.length > 0) {
+              c.tag.forEach(tag => {
+                replacePagesList.push({
+                  fname: page.fname.split("[tags]").join(tag).split("[alias]").join(c.alias),
+                  node: parse(html) as Element,
+                  props: page.props,
+                  tagName: page.tagName,
+                  rawData: html,
+                })
+              })
+            } else {
+              // In this case, content doesn't have tag.
+                replacePagesList.push({
+                  fname: page.fname.split("[alias]").join(c.alias),
+                  node: parse(html) as Element,
+                  props: page.props,
+                  tagName: page.tagName,
+                  rawData: html,
+                })
+            }
+          })
+        } else {
+          // In this case, target file doesn't have [alias] path. 
+          throw new Error(`You specified the cms-tag-loop attribute in ${page.fname}. However, this path doesn't include [tags] directory.`);
+        }
+      } else if (tagAndLoopElement) {
+        // In this case, target file has cms-tag-loop and cms-loop.
+        const tagFieldName = tagAndLoopElement.getAttribute("cms-tag-loop");
+        const contentType  = tagAndLoopElement.getAttribute("cms-content-type");
+        if (!tagFieldName) throw new Error("Yous should specify the cms-tag-loop");
+        if (!contentType) throw new Error("You should specify the cms-content-type");
+
+        if (page.fname.includes("[tags]")) {
+          const apiOption = generateAPIOptionMap(tagAndLoopElement as Element);
+          removeCMSAttributes(tagAndAliasLoopElement as Element);
+
+          const generatedLists = await jsGenerator.generateListGroupByTag(
+            tagAndLoopElement.innerHTML,
+            contentType,
+            apiOption,
+            tagFieldName
+          )
+          generatedLists.forEach(c => {
+            tagAndLoopElement.innerHTML = c.generatedHtml;
+            const html = page.node.innerHTML.replace(
+              tagAndLoopElement.innerHTML,
+              c.generatedHtml
+            )
+            replacePagesList.push({
+              fname: page.fname.split("[tags]").join(c.tag),
+              node: parse(html) as Element,
+              props: page.props,
+              tagName: page.tagName,
+              rawData: html
+            })
+          })
+        } else {
+          // In this case, target file doesn't have [tags] path.
+          throw new Error(`You specified the cms-tag-loop attribute in ${page.fname}. However, this path doesn't include [tags] directory.`);
+        }
+      } else if (aliasLoopElement) {
+        // In this case, target file has cms-item. (This mean we need to treat this file as loop if path contain the [alias].)
+        if (page.fname.includes("[alias]")) {
+          // path contain [alias]
+          const contentType = aliasLoopElement.getAttribute("cms-content-type");
+          if (!contentType) throw new Error("You should specify the cms-content-type in alias page with cms-item");
+
+          const apiOption = generateAPIOptionMap(aliasLoopElement as Element);
+          removeCMSAttributes(aliasLoopElement as Element);
+          const generatedContents = await jsGenerator.generateEachContentFromList(
+            aliasLoopElement.innerHTML,
+            contentType,
+            apiOption
+          );
+          generatedContents.forEach(c => {
+            aliasLoopElement.innerHTML = c.generatedHtml;
+            const html = page.node.innerHTML.replace(
+              aliasLoopElement.innerHTML,
+              c.generatedHtml
+            );
+            replacePagesList.push({
+              fname: page.fname.split("[alias]").join(c.alias),
+              node: parse(html) as Element,
+              props: page.props,
+              tagName: page.tagName,
+              rawData: html,
+            })
+          })
+        } else {
+          // path doesn't contain [alias]. So we need to treat this file as item file.
+          replacePagesList.push({
+            fname: page.fname,
+            node: parse(page.node.innerHTML) as Element,
+            props: page.props,
+            tagName: page.tagName,
+            rawData: page.rawData,
+          })
+        }
+      }
+    } else if (page.fname.includes("[alias]") && page.node.querySelector("[cms-item]")) {
+      const targetElement = page.node.querySelector("[cms-item]");
+      // [alias].html only (This mean path doesn't be included the [tags].)
       const contentId = targetElement.getAttribute("cms-content-type");
+      if (!contentId) throw new Error("You should specify the cms-content-type in alias page with cms-item.");
+
       const apiOption = generateAPIOptionMap(targetElement as Element);
       removeCMSAttributes(targetElement as Element);
       const generatedContents = await jsGenerator.generateEachContentFromList(

--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -146,14 +146,11 @@ export class SpearlyJSGenerator {
             }
 
             const result = await this.client.getList(contentType, generateGetParamsFromAPIOptions(apiOption))
-            const allTags = [] as string[]
+            let allTags = [] as string[]
             result.data.forEach(content => {
-                const tags = content.attributes.fields.data.filter(field => {
-                    field.attributes.identifier === tagFieldName
-                    return field
-                }) as FieldTypeTags[]
+                const tags = content.attributes.fields.data.filter(field => field.attributes.identifier === tagFieldName) as FieldTypeTags[]
                 if (tags && tags.length === 1)
-                    allTags.concat(tags[0].attributes.value)
+                    allTags = allTags.concat(tags[0].attributes.value)
             })
             const tags = [...new Set(allTags.flat())]
             const contentsByTag: GeneratedListContent[] = []
@@ -169,6 +166,11 @@ export class SpearlyJSGenerator {
                 let resultHtml = ""
                 targetContents.forEach(c => {
                     const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, variableName  || contentType, 2, true, this.options.dateFormatter);
+                    // Special replacement string
+                    replacementArray.push({
+                        definitionString: `{%= ${contentType}_#tag %}`,
+                        fieldValue: tag,
+                    })
                     resultHtml += this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType)
                 })
                 contentsByTag.push({
@@ -189,9 +191,9 @@ export class SpearlyJSGenerator {
             result.data.forEach(c => {
                 const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, contentType, 2, true, this.options.dateFormatter)
                 const tags = c.attributes.fields.data.filter(field => field.attributes.identifier === tagFieldName)
-                const tag: string[] = []
+                let tag: string[] = []
                 if (tags && tags.length > 0 && Array.isArray(tags[0].attributes.value)) {
-                    tag.concat(tags[0].attributes.value as [])
+                    tag = tag.concat(tags[0].attributes.value as [])
                 }
 
                 generatedContents.push({


### PR DESCRIPTION
## What is this ?

This PR will make the spear to support tag loop.
The specification is the following:  
https://github.com/unimal-jp/spear/issues/123#issuecomment-1457290793

## How do we use it?

There are several pattern for this tag loop routing.

### 1. Use `cms-tag-loop` attribute with `cms-item` attribute

If we put the following HTML into specified path which has `[alias]` and `[tags]`, Spear will generate the article each tag directories.

```html
...
  <div cms-item cms-content-type="blog" cms-tag-loop="tag">
    <h1>{%= blog_title %}</h1>
  </div>
...
```

In above sample, we put it into `/src/article/[tags]/[alias].html` and we have the three contents:

| content(alias name) | title | tag |
| - | - | - |
| ContentA | First Blog | Lifework, Technology |
| ContentB | Second Blog | Technology, University |
| ContentC | Third Blog | Lifework, University |

The spear will generate the following structures:

```
|- article
|      |- Lifework
|      |       |- ContentA.html
|      |       |- ContentC.html
|      |- Technology
|      |       |- ContentA.html
|      |       |- ContentB.html
|      |- University
|      |       |- ContentB.html
|      |       |- ContentC.html
```

### 2. Use `cms-tag-loop` attribute with `cms-loop` attribute

If we pu the following HTML into specified path which has `[tags]`, Spear will generate the article list page into each tag directories.

```html
...
  <div cms-loop cms-content-type="blog" cms-tag-loop="tag">
    <h1>{%= blog_title %}</h1>
  </div>
...
```

In above sample, we put into `/src/article/[tags]/index.html` and we have the three contents:

| content(alias name) | title | tag |
| - | - | - |
| ContentA | First Blog | Lifework, Technology |
| ContentB | Second Blog | Technology, University |
| ContentC | Third Blog | Lifework, University |

The spear will generate the following structures:

```
|- article
|      |- Lifework
|      |       |- index.html
|      |- Technology
|      |       |- index.html
|      |- University
|      |       |- index.html
```


-----

## これはなに？

この PR で Spear にタグループ機能を追加しています。
仕様は以下のスレッドで議論しています。  
https://github.com/unimal-jp/spear/issues/123#issuecomment-1457290793

## 使い方

タグループルーティングを使うにはいくつか方法が有ります。

### 1. `cms-tag-loop` 属性と  `cms-item` 属性を利用する

もし以下のようなHTMLを `[alias]` と `[tags]` を持つパスに保存すると、Spear は各タグごとのディレクトリへ記事を生成してくれます。

```html
...
  <div cms-item cms-content-type="blog" cms-tag-loop="tag">
    <h1>{%= blog_title %}</h1>
  </div>
...
```

上記サンプルで、もし `/src/article/[tags]/[alias].html` というファイルに保存し、以下の3つのコンテンツがある場合

| コンテンツ(エイリアス名) | title | tag |
| - | - | - |
| ContentA | First Blog | Lifework, Technology |
| ContentB | Second Blog | Technology, University |
| ContentC | Third Blog | Lifework, University |

Spear は以下のディレクトリ構造でファイルを生成します。

```
|- article
|      |- Lifework
|      |       |- ContentA.html
|      |       |- ContentC.html
|      |- Technology
|      |       |- ContentA.html
|      |       |- ContentB.html
|      |- University
|      |       |- ContentB.html
|      |       |- ContentC.html
```

### 2. `cms-tag-loop` 即税と `cms-loop` 属性を利用する

もし以下のようなHTMLを`[tags]`が含まれるパスに保存した場合、Spear は記事のリストをタグごとのディレクトリへ生成します。

```html
...
  <div cms-loop cms-content-type="blog" cms-tag-loop="tag">
    <h1>{%= blog_title %}</h1>
  </div>
...
```

上記例のファイルを `/src/article/[tags]/index.html` に置いて、以下のコンテンツがある場合

| コンテンツ(エイリアス名) | title | tag |
| - | - | - |
| ContentA | First Blog | Lifework, Technology |
| ContentB | Second Blog | Technology, University |
| ContentC | Third Blog | Lifework, University |

Spear は以下のディレクトリ構造でファイルを生成します。

```
|- article
|      |- Lifework
|      |       |- index.html  (ContentA and ContentC)
|      |- Technology
|      |       |- index.html  (ContentA and ContentB)
|      |- University
|      |       |- index.html  (ContentB and ContentC)
```


