### PR TITLE
Support component on slot

### DIFF
--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -72,7 +72,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
     }
 
     compileSASS(filePath: string): string {
-      const result = sass.compile(filePath);
+      const result = sass.compileString(filePath);
       return result.css;
     }
 

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -109,6 +109,8 @@ async function bundle(): Promise<boolean> {
   // Run list again to parse children of the pages
   for (const page of state.pagesList) {
     page.node.childNodes = await parseElements(state, page.node.childNodes as Element[], jsGenerator)
+    // We need to parseElement twice due to embed nested component.
+    page.node.childNodes = await parseElements(state, page.node.childNodes as Element[], jsGenerator)
   }
 
   // generate static routing files.

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -109,7 +109,7 @@ export function insertComponentSlot(componentElement: Element, parentElement: El
 
     // Single Slot
     const slotElement = slotElements[0]
-    console.log(`parentElement: [${parentElement.innerHTML}]`)
+    slotElement.removeAttribute("name")
     if (parentElement.innerHTML !== "") {
       slotElement.insertAdjacentHTML('afterend', parentElement.innerHTML)
       slotElement.remove()
@@ -123,6 +123,7 @@ export function insertComponentSlot(componentElement: Element, parentElement: El
     // Multiple Slot(Mean named slot)
     for (const slotElement of slotElements) {
       const slotName = slotElement.getAttribute("name")
+      slotElement.removeAttribute("name")
       // TODO: We need to conditional process for slotname is undefined.
       const parentSlotReplaceElement = parentElement.querySelector(`[slot="${slotName}"]`)
       if (parentSlotReplaceElement) {


### PR DESCRIPTION
## What is this?

This PR will fix the bug that fail to build when using component into slot.

Previous Spear might fail the following sources:

- index.html
```html
<body>
  <content-component>
    <div slot="mainContent">
      <sub-component>
        <p slot="sub">Specified from index.html</p>
      </sub-component>
    </div>
  </content-component>
</body>
```

- components/content-component.spear
```html
<div>
  <header>
    <p>Header</p>
  </header>
  <slot name="mainContent">
  </slot>
</div>
```

- components/sub-component.spear
```html
<div>
  <slot name="sub">Fallback of sub-component.</slot>
</div>
```

Expected result is the following. But current version will fail building it.

```
<body>
    <div>
        <header>
            <p>Header</p>
        </header>
        <div>
            <div>
                <p>Specified from index.html</p>
            </div>
        </div>
    </div>
</body>
```

So this patch will make Spear parse the element twice in order to allow the in-slot-component.

---

＃＃ これは何ですか？

この PR は、コンポーネントをスロットに使用するとビルドに失敗するバグを修正します。

以前の Spear は、次のソースに失敗する可能性があります。

- index.html
html
<body>
   <content-component>
     <div slot="mainContent">
       <sub-component>
         <p slot="sub">index.html から指定</p>
       </sub-component>
     </div>
   </content-component>
</body>
```

- components/content-component.spear
html
<div>
   <ヘッダー>
     <p>ヘッダー</p>
   </header>
   <スロット名="mainContent">
   </スロット>
</div>
```

- components/sub-component.spear
html
<div>
   <slot name="sub">サブコンポーネントのフォールバック。</slot>
</div>
```

期待される結果は次のとおりです。 ただし、現在のバージョンではビルドに失敗します。

```
<body>
     <div>
         <header>
             <p>ヘッダー</p>
         </header>
         <div>
             <div>
                 <p>index.html から指定</p>
             </div>
         </div>
     </div>
</body>
```

そのため、このパッチでは、スロット内コンポーネントを許可するために、Spear が要素を 2 回解析するようにします。