### PR TITLE
SASS Building based on filepath

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "type": "module",
   "description": "",
   "preferGlobal": true,
@@ -33,7 +33,7 @@
     "url": "https://github.com/unimal-jp/spear/issues"
   },
   "dependencies": {
-    "@spearly/cms-js-core": "^1.0.7",
+    "@spearly/cms-js-core": "^1.0.9",
     "@types/live-server": "^1.2.1",
     "argparse": "^2.0.1",
     "chalk": "^5.2.0",
@@ -44,7 +44,7 @@
     "live-server": "^1.1.0",
     "node-html-parser": "^5.3.3",
     "node-watch": "^0.7.3",
-    "sass": "^1.57.1",
+    "sass": "^1.59.3",
     "sitemap": "^7.1.1",
     "yaml": "^2.2.1"
   },

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -72,7 +72,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
     }
 
     compileSASS(filePath: string): string {
-      const result = sass.compileString(filePath);
+      const result = sass.compile(filePath);
       return result.css;
     }
 

--- a/packages/spear-cli/src/utils/file.ts
+++ b/packages/spear-cli/src/utils/file.ts
@@ -160,8 +160,7 @@ export class FileUtil {
           relatePath + (relatePath !== "" ? "/" : "") + file
         );
       } else if (needSASSBuild(ext)) {
-        const rawData = this.manipulator.readFileSync(filePath, "utf8");
-        const css = this.manipulator.compileSASS(rawData);
+        const css = this.manipulator.compileSASS(filePath);
         state.out.assetsFiles.push({
           filePath: `${relatePath}/${fname}.css`,
           rawData: Buffer.from(css),

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -101,45 +101,6 @@ export function removeCMSAttributes(node: Element) {
   }
 }
 
-export function insertComponentSlot(componentElement: Element, parentElement: Element): string {
-  const slotElements = componentElement.querySelectorAll("slot")
-  // If component has not <Slot> element, return component html string as is.
-  if (slotElements.length <= 0) return componentElement.innerHTML
-  if (slotElements.length === 1) {
-
-    // Single Slot
-    const slotElement = slotElements[0]
-    slotElement.removeAttribute("name")
-    if (parentElement.innerHTML !== "") {
-      slotElement.insertAdjacentHTML('afterend', parentElement.innerHTML)
-      slotElement.remove()
-    } else {
-      // Fallback. remove slot element and insert inner of SLot
-      slotElement.insertAdjacentHTML('afterend', slotElement.innerHTML)
-      slotElement.remove()
-    }
-    return componentElement.innerHTML
-  } else {
-    // Multiple Slot(Mean named slot)
-    for (const slotElement of slotElements) {
-      const slotName = slotElement.getAttribute("name")
-      slotElement.removeAttribute("name")
-      // TODO: We need to conditional process for slotname is undefined.
-      const parentSlotReplaceElement = parentElement.querySelector(`[slot="${slotName}"]`)
-      if (parentSlotReplaceElement) {
-        parentSlotReplaceElement.removeAttribute("slot")
-        slotElement.insertAdjacentHTML('afterend', parentSlotReplaceElement.outerHTML)
-        slotElement.remove()
-      } else {
-        slotElement.insertAdjacentHTML('afterend', slotElement.innerHTML)
-        slotElement.remove()
-      }
-    }
-    return componentElement.innerHTML
-  }
-}
-
-
 export function isParseTarget(ext: string) {
   return [".html", ".htm", ".spear"].includes(ext)
 }

--- a/packages/spearly-cms-js-core/package.json
+++ b/packages/spearly-cms-js-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spearly/cms-js-core",
   "private": false,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
### What is this fix?

This PR will fix the sass building failure.  
Previous implementation is building the SASS context. So Spear fail when using `@import` syntax of SCSS.

This PR will use the file path when building the SCSS.

Furthermore, This PR contains:
- Version up (spear-cli: 1.2.5 / spearly-cms-js-core: 1.0.9)
- Remove unused function.