### PR TITLE
Support silent mode.

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -20,7 +20,9 @@
     "spear": "./dist/index.js"
   },
   "exports": {
-    ".": "./dist/browser/InMemoryMagic.js"
+    ".": "./dist/browser/InMemoryMagic.js",
+    "./dist/plugins/*": "./dist/plugins/*",
+    "./plugins/*": "./dist/plugins/*.js"
   },
   "keywords": [],
   "author": "Yo",

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -6,6 +6,7 @@ import { generateAliasPagesFromPagesList, parseElements } from "../utils/dom.js"
 import { InMemoryFile, Settings } from "../interfaces/FileManipulatorInterface";
 import { Component, Element, State } from "../interfaces/MagicInterfaces";
 import { InMemoryFileManipulator } from "../file/InMemoryFileManipulator";
+import { SpearLog } from "../utils/log.js";
 
 /**
  * inMemoryMagic
@@ -17,6 +18,9 @@ export default async function inMemoryMagic(
   inputFiles: InMemoryFile[],
   settings: Settings
 ) {
+  // Initial Settings
+  settings.quiteMode = settings.quiteMode || false;
+  const logger = new SpearLog(settings.quiteMode);
   const jsGenerator = new SpearlyJSGenerator(
     settings.spearlyAuthKey,
     settings.apiDomain
@@ -60,13 +64,13 @@ export default async function inMemoryMagic(
     createdAt: new Date(),
     updatedAt: new Date(),
   })
-  const fileUtil = new FileUtil(new InMemoryFileManipulator(inputFiles, settings));
+  const fileUtil = new FileUtil(new InMemoryFileManipulator(inputFiles, settings), logger);
 
   // Hook API: beforeBuild
   for (const plugin of settings.plugins) {
     if (plugin.beforeBuild) {
       try {
-        const newState = await plugin.beforeBuild(state, { fileUtil });
+        const newState = await plugin.beforeBuild(state, { fileUtil, logger });
         if (newState) {
           state = stateDeepCopy(newState);
         }
@@ -87,7 +91,7 @@ export default async function inMemoryMagic(
       await fileUtil.parseComponents(state, componentsFolder);
     }
   } catch (e) {
-    console.log(e);
+    logger.log(e);
     return false;
   }
 
@@ -96,7 +100,7 @@ export default async function inMemoryMagic(
       await fileUtil.parsePages(state, srcDir);
     }
   } catch (e) {
-    console.log(e);
+    logger.log(e);
     return false;
   }
   
@@ -134,7 +138,7 @@ export default async function inMemoryMagic(
   for (const plugin of settings.plugins) {
     if (plugin.afterBuild) {
       try {
-        const newState = await plugin.afterBuild(state, { fileUtil });
+        const newState = await plugin.afterBuild(state, { fileUtil, logger });
         if (newState) {
           state = stateDeepCopy(newState);
         }
@@ -154,7 +158,7 @@ export default async function inMemoryMagic(
   for (const plugin of settings.plugins) {
     if (plugin.bundle) {
       try {
-        const newState = await plugin.bundle(state, { fileUtil });
+        const newState = await plugin.bundle(state, { fileUtil, logger });
         if (newState) {
           state = stateDeepCopy(newState);
         }

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -85,7 +85,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
         );
         return data.toString()
       } catch (e) {
-        console.log(e);
+        console.error(e);
       }
     }
 

--- a/packages/spear-cli/src/index.ts
+++ b/packages/spear-cli/src/index.ts
@@ -24,8 +24,6 @@ parser.add_argument("-s", "--src", { help: "Specify source directory. "})
 
 const args = parser.parse_args()
 
-console.log(args)
-
 if (args.action === "watch" || args.action === "build") {
   if (!magic(args)) {
     // Notify caller to magic fail.

--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -1,6 +1,7 @@
 import { DefaultSettings } from "./SettingsInterfaces"
 import { HTMLElement } from "node-html-parser"
 import { FileUtil } from "../utils/file"
+import { SpearLog } from "../utils/log"
 
 export type SpearSettings = DefaultSettings
 
@@ -30,7 +31,8 @@ export interface SpearState {
 }
 
 export interface SpearOption {
-  fileUtil: FileUtil
+  fileUtil: FileUtil,
+  logger: SpearLog
 }
 
 /**

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -16,5 +16,6 @@ export interface DefaultSettings {
   generateSitemap: boolean,
   siteURL: string,
   rootDir: string,
-  plugins: HookApi[]
+  plugins: HookApi[],
+  quiteMode?: boolean,
 }

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -237,6 +237,8 @@ export async function generateAliasPagesFromPagesList(
       }
     } else if (page.fname.includes("[alias]")) {
       const targetElement = page.node.querySelector("[cms-item]");
+      if (!targetElement) continue;
+
       if (targetElement.getAttribute("cms-ignore-static")) continue;
       // [alias].html only (This mean path doesn't be included the [tags].)
       const contentId = targetElement.getAttribute("cms-content-type");
@@ -280,7 +282,6 @@ function insertComponentSlot(
   if (slotElements.length === 1) {
     // Single Slot
     const slotElement = slotElements[0];
-    console.log(`parentElement: [${parentElement.innerHTML}]`);
     if (parentElement.innerHTML !== "") {
       slotElement.insertAdjacentHTML("afterend", parentElement.innerHTML);
       slotElement.remove();

--- a/packages/spear-cli/src/utils/file.ts
+++ b/packages/spear-cli/src/utils/file.ts
@@ -6,11 +6,14 @@ import { minify } from "html-minifier-terser";
 import { parse } from "node-html-parser";
 import { DefaultSettings } from "../interfaces/SettingsInterfaces";
 import { FileManipulatorInterface } from "../interfaces/FileManipulatorInterface";
+import { SpearLog } from "./log";
 
 export class FileUtil {
   manipulator: FileManipulatorInterface;
-  constructor(manipulator: FileManipulatorInterface) {
+  logger: SpearLog
+  constructor(manipulator: FileManipulatorInterface, logger: SpearLog) {
     this.manipulator = manipulator;
+    this.logger = logger;
   }
 
   loadFile(filePath: string): Promise<any> {
@@ -25,8 +28,8 @@ export class FileUtil {
     if (!this.manipulator.existsSync(dirPath)) return;
     const files = this.manipulator.readdirSync(dirPath);
 
-    console.log("");
-    console.log("[Parse components]");
+    this.logger.log("");
+    this.logger.log("[Parse components]");
 
     for (const file of files) {
       const filePath = `${dirPath}/${file}`;
@@ -53,7 +56,7 @@ export class FileUtil {
             `Component[${tagName}] is built-in HTML tag. You need specify other name.`
           );
         }
-        console.log(`  [Component]: ${fname}`);
+        this.logger.log(`  [Component]: ${fname}`);
         state.componentsList.push({
           fname,
           tagName,
@@ -96,8 +99,8 @@ export class FileUtil {
       } else {
         indexNode = page.node;
       }
-      console.log("");
-      console.log(`[Page]: ${page.fname}`);
+      this.logger.log("");
+      this.logger.log(`[Page]: ${page.fname}`);
 
       // Inject title
       if (indexNode) {
@@ -122,13 +125,13 @@ export class FileUtil {
     }
 
     // Generate Sitemap
-    if (settings.generateSitemap) {
+    if (settings.generateSitemap && linkList.length > 0) {
       try {
         const data = await this.manipulator.generateSiteMap(linkList, settings.siteURL)
-        console.log(`[Sitemap]: /sitemap.xml`);
+        this.logger.log(`[Sitemap]: /sitemap.xml`);
         this.writeFile(`${settings.distDir}/sitemap.xml`, data);
       } catch (e) {
-        console.log(e);
+        this.logger.error(e);
       }
     }
 
@@ -146,8 +149,8 @@ export class FileUtil {
     if (!this.manipulator.existsSync(dirPath)) return;
     const files = this.manipulator.readdirSync(dirPath);
 
-    console.log("");
-    console.log("[Parse Pages]");
+    this.logger.log("");
+    this.logger.log("[Parse Pages]");
 
     for (const file of files) {
       const filePath = `${dirPath}/${file}`;
@@ -183,7 +186,7 @@ export class FileUtil {
         const tagName = fname.toLowerCase(); // todo: keep lowerCase?
         const node = parse(minified) as Element;
 
-        console.log(`  [Page]: ${fname}(/${relatePath})`);
+        this.logger.log(`  [Page]: ${fname}(/${relatePath})`);
         state.pagesList.push({
           fname: `${relatePath}/${fname}`,
           tagName,

--- a/packages/spear-cli/src/utils/log.ts
+++ b/packages/spear-cli/src/utils/log.ts
@@ -1,0 +1,32 @@
+export class SpearLog {
+    private quite: boolean;
+    constructor(quite :boolean) {
+        this.quite = quite;
+    }
+
+    get isQuite() {
+        return this.quite;
+    }
+
+    set isQuite(value: boolean) {
+        this.quite = value;
+    }
+
+    log(...args: any[]) {
+        if (!this.quite) {
+            console.log(...args);
+        }
+    }
+
+    warn(...args: any[]) {
+        if (!this.quite) {
+            console.warn(...args);
+        }
+    }
+
+    error(...args: any[]) {
+        if (!this.quite) {
+            console.error(...args);
+        }
+    }
+}


### PR DESCRIPTION
### What is this?

This PR will make the spear to support silent mode.   
This silent mode will be not output any information in console.  

For example, If we implement spear into browser, the console output of Spear is too noisy now. So I introduce the `SpearLog` class and support the silent mode.

Furthermore, this PR will fix nit bugs:
- Compatibility of import syntax in `spear.config.mjs`. (Previous version is missing the import syntax in `spear.config.mjs`)
- If generated result page is zero, Spear is crashed.

### How to use it?

You can use silent mode by specifying option into `spear.config.mjs`:

```
export default {
  "projectName": "test",
  "plugins": [
    spearI18n("./i18n.yaml"),
  ],
  "quiteMode": true,
};
```

---

### これは何ですか？

この PR は、Spear をサイレントモードに対応させるものです。  
このサイレントモードは、コンソールに情報を出力しないようにします。 

例えば、spear をブラウザに実装した場合、Spear のコンソール出力がうるさくなってしまいます。そこで、`SpearLog` クラスを導入し、サイレントモードをサポートします。

さらに、この PR では以下のようなバグも修正されます：
- spear.config.mjs` の import 構文に互換性を持たせました。(以前のバージョンでは `spear.config.mjs` の import 構文が抜けていました)
- 生成された結果ページがゼロの場合、Spearはクラッシュします。

### どう使うの？

spear.config.mjs`にオプションを指定することで、サイレントモードを使用することができます：

```
export default {
  "projectName": "test",
  "plugins": [
    spearI18n("./i18n.yaml"),
  ],
  "quiteMode": true,
};
```