### PR TITLE
Support generate target option.

### DIFF
--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -22,7 +22,6 @@ export default async function inMemoryMagic(
   settings.quiteMode = settings.quiteMode || false;
   const logger = new SpearLog(settings.quiteMode);
   settings.targetPagesPathList = settings.targetPagesPathList || [];
-  console.log(settings);
 
   const jsGenerator = new SpearlyJSGenerator(
     settings.spearlyAuthKey,
@@ -136,7 +135,6 @@ export default async function inMemoryMagic(
 
   // This process is only for the in-browser mode.
   // If specified targetPagesPathList is not empty, replace the state.pagesList with the specified pages.
-  console.log(state.pagesList);
   if (settings.targetPagesPathList.length > 0) {
     const targetPagesList = [] as State["pagesList"];
     for (const targetPagePath of settings.targetPagesPathList) {
@@ -148,11 +146,7 @@ export default async function inMemoryMagic(
       }
     }
     state.pagesList = targetPagesList;
-    console.log(targetPagesList);
   }
-
-  console.log(settings.targetPagesPathList);
-  console.log(state.pagesList);
 
   // generate static routing files.
   state.pagesList = await generateAliasPagesFromPagesList(state, jsGenerator);

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -17,6 +17,8 @@ export default async function inMemoryMagic(
   inputFiles: InMemoryFile[],
   settings: Settings
 ) {
+  settings.targetPagesPathList = settings.targetPagesPathList || [];
+  console.log(settings);
   const jsGenerator = new SpearlyJSGenerator(
     settings.spearlyAuthKey,
     settings.apiDomain
@@ -126,6 +128,26 @@ export default async function inMemoryMagic(
       jsGenerator
     );
   }
+
+  // This process is only for the in-browser mode.
+  // If specified targetPagesPathList is not empty, replace the state.pagesList with the specified pages.
+  console.log(state.pagesList);
+  if (settings.targetPagesPathList.length > 0) {
+    const targetPagesList = [] as State["pagesList"];
+    for (const targetPagePath of settings.targetPagesPathList) {
+      const targetPage = state.pagesList.find(
+        (page) => page.fname === targetPagePath
+      );
+      if (targetPage) {
+        targetPagesList.push(targetPage);
+      }
+    }
+    state.pagesList = targetPagesList;
+    console.log(targetPagesList);
+  }
+
+  console.log(settings.targetPagesPathList);
+  console.log(state.pagesList);
 
   // generate static routing files.
   state.pagesList = await generateAliasPagesFromPagesList(state, jsGenerator);

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -16,5 +16,7 @@ export interface DefaultSettings {
   generateSitemap: boolean,
   siteURL: string,
   rootDir: string,
-  plugins: HookApi[]
+  plugins: HookApi[],
+  // This option is for the in-browser mode option.
+  targetPagesPathList?: string[],
 }


### PR DESCRIPTION
### What is this ?

This PR will make the Spear to support option which specifying generating target.

For example:

We specify the following option in `InMemoryMagic` (Browser mode. First parameter is whole of files, Second parameter is option)

```
InMemoryMagic(files, {
    projectName: "Sample Program",
    spearlyAuthKey: "AUTH_KEY",
    plugins: [],
    componentsFolder: ["/src/components"],
    srcDir: ["/src"],
    distDir: "dist",
    quiteMode: false,
    targetPagesPathList: [ '/index'  ],
  });
```

As result of above sample, spear will generate `index.html` only.

