### PR TITLE
Fix: Support i18n's default fallback.

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -31,7 +31,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
               } else if (ext === ".json") {
                 const data = this.readFileSync(files[0], "utf8");
                 resolve(JSON.parse(data));
-              } else if (ext === ".yaml") {
+              } else if (ext === ".yaml" || ext === ".yml") {
                 const data = this.readFileSync(files[0], "utf8");
                 resolve(yamlParse(data));
               } else {

--- a/packages/spear-cli/src/plugins/spear-i18n.ts
+++ b/packages/spear-cli/src/plugins/spear-i18n.ts
@@ -14,6 +14,14 @@ const i18nSettings: I18nSettings = {
     default: "",
 }
 const i18nLanguages: I18nLanguages = new Map<string, I18nWords>()
+const generateDefaultFallbackHtml = () => `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- redirect to default language -->
+  <meta http-equiv="refresh" content="0; url=/${i18nSettings.default}/">
+</head><body></body>
+</html>`;
 
 // This plugin will replace i18n syntax.
 // SettingsFile:
@@ -21,7 +29,6 @@ const i18nLanguages: I18nLanguages = new Map<string, I18nWords>()
 //   export default {
 //     settings: {
 //       default: "jp",
-//       fallback: "jp",
 //     },
 //     "jp": [
 //       { title: "ブログです" },
@@ -35,7 +42,6 @@ const i18nLanguages: I18nLanguages = new Map<string, I18nWords>()
 //  Or Yaml object file which has key and value like the bellow:
 //    settings:
 //      default: "jp"
-//      fallback: "jp"
 //    lang:
 //      jp:
 //        - title: ブログだよ
@@ -115,7 +121,7 @@ async function generateI18nBeforeBundle(state: SpearState, logger: SpearLog): Pr
                 indexNode = parse(page.node.outerHTML) as Element
             }
 
-            // i18n attributes process
+            // Replace i18n attributes
             // If we found the i18n attr, replace all of child to translate word
             const i18nAttrs = indexNode.querySelectorAll("[i18n]")
             i18nAttrs.forEach(i18nElement => {
@@ -187,6 +193,18 @@ async function generateI18nBeforeBundle(state: SpearState, logger: SpearLog): Pr
             assetsFiles.push({
                 filePath: `/${lang}/${asset.filePath}`,
                 rawData: bufferDeepCopy(asset.rawData),
+            })
+        }
+
+        // Generate fallback page.
+        if (i18nSettings.default === lang) {
+            const html = generateDefaultFallbackHtml();
+            pageList.push({
+                fname: "/index",
+                tagName: "html",
+                rawData: html,
+                node: parse(html) as Element,
+                props: {},
             })
         }
     })


### PR DESCRIPTION
## What is this ?

This PR fix the #151 issue.

Current Spear doesn't generate the i18n default fallback page.  
After landing this PR, the generated result page structure is the following:

```
tests/i18n-test/dist
├── en
│   ├── articles
│   │   └── index.html
│   ├── assets
│   │   ├── css
│   │   │   └── main.css
│   │   ├── fonts
│   │   │   └── OpenSans-Regular.ttf
│   │   └── js
│   │       └── main.js
│   ├── images
│   │   └── logo.png
│   └── index.html
├── index.html
└── jp
    ├── articles
    │   └── index.html
    ├── assets
    │   ├── css
    │   │   └── main.css
    │   ├── fonts
    │   │   └── OpenSans-Regular.ttf
    │   └── js
    │       └── main.js
    ├── images
    │   └── logo.png
    └── index.html
```

The `index.html` of top directory is the fallback page. This fallback page redirect to default language's index.html. This mean that spear generate the following HTML:

```
<!DOCTYPE html>
<html lang="en">
<head>
  
  <meta http-equiv="refresh" content="0; url=/jp/">
</head><body></body>
</html>%   
```

----

## これはなに？

#151 の修正PRです。

現時点で Spear はデフォルト言語へのフォールバックページを生成していません。
このPR以降では、生成されたページの構造は以下のようになります。

```
tests/i18n-test/dist
├── en
│   ├── articles
│   │   └── index.html
│   ├── assets
│   │   ├── css
│   │   │   └── main.css
│   │   ├── fonts
│   │   │   └── OpenSans-Regular.ttf
│   │   └── js
│   │       └── main.js
│   ├── images
│   │   └── logo.png
│   └── index.html
├── index.html
└── jp
    ├── articles
    │   └── index.html
    ├── assets
    │   ├── css
    │   │   └── main.css
    │   ├── fonts
    │   │   └── OpenSans-Regular.ttf
    │   └── js
    │       └── main.js
    ├── images
    │   └── logo.png
    └── index.html
```

トップディレクトリの `index.html` はフォールバックページです。このフォールバックページはデフォルト言語の `index.html` へリダイレクトします。生成されるページは以下のようになります。

```
<!DOCTYPE html>
<html lang="en">
<head>
  
  <meta http-equiv="refresh" content="0; url=/jp/">
</head><body></body>
</html>%   
```

