### PR TITLE
Support plugin name for debugging.

### DIFF
--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -76,6 +76,7 @@ export interface BundleHookFunction {
  * You can specify this object into spear.config.mjs.
  */
 export interface HookApi {
+    pluginName: string,
     configuration?: ConfigurationHookFunction,
     beforeBuild?: BeforeBuildHookFunction,
     afterBuild? : AfterBuildHookFunction,

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -72,7 +72,7 @@ async function bundle(): Promise<boolean> {
       } catch (e) {
         // TODO. This error should have a plugin information.
         // For more information, see the https://github.com/unimal-jp/spear/issues/111
-        console.warn(` plugin process failed. `)
+        console.warn(` plugin process failed. [${plugin.pluginName}]`)
       }
     }
   }
@@ -134,7 +134,7 @@ async function bundle(): Promise<boolean> {
       } catch (e) {
         // TODO. This error should have a plugin information.
         // For more information, see the https://github.com/unimal-jp/spear/issues/111
-        console.warn(` plugin process failed. `)
+        console.warn(` plugin process failed. [${plugin.pluginName}]`)
       }
     }
   }
@@ -153,7 +153,7 @@ async function bundle(): Promise<boolean> {
       } catch (e) {
         // TODO. This error should have a plugin information.
         // For more information, see the https://github.com/unimal-jp/spear/issues/111
-        console.warn(` plugin process failed. `)
+        console.warn(` plugin process failed. ${plugin.pluginName}}`)
       }
     }
   }
@@ -200,7 +200,7 @@ export default async function magic(args: Args): Promise<boolean> {
       } catch (e) {
         // TODO. This error should have a plugin information.
         // For more information, see the https://github.com/unimal-jp/spear/issues/111
-        console.warn(` plugin process failed. `)
+        console.warn(` plugin process failed. ${plugin.pluginName}}}`)
       }
     }
   }

--- a/packages/spear-cli/src/plugins/spear-i18n.ts.orig
+++ b/packages/spear-cli/src/plugins/spear-i18n.ts.orig
@@ -48,7 +48,6 @@ export function spearI18n(settingsFile?: string): HookApi {
     let logger: SpearLog
     // Use configuration and afterBuild hook for generating SEO.
     return {
-        pluginName: "spear-i18n",
         // Build internal variable for converting i18n
         configuration: async function(settings: SpearSettings, option: SpearOption) {
             logger = option.logger

--- a/packages/spear-cli/src/plugins/spear-seo.ts
+++ b/packages/spear-cli/src/plugins/spear-seo.ts
@@ -14,6 +14,7 @@ export function spearSEO(settingsFile?: string): HookApi {
     let logger: SpearLog
     // Use configuration and afterBuild hook for generating SEO.
     return {
+        pluginName: "spear-seo",
         configuration: async function(settings: SpearSettings, option: SpearOption) {
             logger = option.logger
             globalSettings = new Map<string, string>()


### PR DESCRIPTION
### What is this?

This fix is for debugging of plugin.  
At the moment, plugin doesn't have a plugin name, so spear didn't output the plugin name when error happened into plugin.

This PR will fix it.

