### PR TITLE
Fix In-Browser mode bugs.

### DIFF
--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -18,7 +18,6 @@ export default async function inMemoryMagic(
   inputFiles: InMemoryFile[],
   settings: Settings
 ) {
-  console.log(inputFiles, settings);
   // Initial Settings
   settings.quiteMode = settings.quiteMode || false;
   const logger = new SpearLog(settings.quiteMode);
@@ -191,7 +190,6 @@ export default async function inMemoryMagic(
   const distFiles = fileUtil.manipulator.readdirSync("dist");
   const returnFiles = [] as InMemoryFile[];
   for (const file of distFiles) {
-    console.log(file);
     if (file && file !== '' && !fileUtil.manipulator.isDirectory(`dist/${file}`)) {
       returnFiles.push((fileUtil.manipulator as InMemoryFileManipulator).getInMemoryFile(`dist/${file}`));
     }

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -18,6 +18,7 @@ export default async function inMemoryMagic(
   inputFiles: InMemoryFile[],
   settings: Settings
 ) {
+  console.log(inputFiles, settings);
   // Initial Settings
   settings.quiteMode = settings.quiteMode || false;
   const logger = new SpearLog(settings.quiteMode);
@@ -190,7 +191,8 @@ export default async function inMemoryMagic(
   const distFiles = fileUtil.manipulator.readdirSync("dist");
   const returnFiles = [] as InMemoryFile[];
   for (const file of distFiles) {
-    if (!fileUtil.manipulator.isDirectory(`dist/${file}`)) {
+    console.log(file);
+    if (file && file !== '' && !fileUtil.manipulator.isDirectory(`dist/${file}`)) {
       returnFiles.push((fileUtil.manipulator as InMemoryFileManipulator).getInMemoryFile(`dist/${file}`));
     }
   }

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -12,7 +12,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
 
     getInMemoryFile(path: string): InMemoryFile {
         for (const file of this.files) {
-            if (file.path === path) return file
+            if (this.isSamePath(file.path, path)) return file
         }
         return null
     }
@@ -22,14 +22,14 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     readFileSync(path: string, encode: string): string {
         for (const file of this.files) {
-            if (file.path === path) return file.content
+            if (this.isSamePath(file.path, path)) return file.content
         }
         return ""
     }
 
     readFileSyncAsBuffer(path: string): Buffer {
         for (const file of this.files) {
-            if (file.path === path) return Buffer.from(file.content, 'base64')
+            if (this.isSamePath(file.path, path)) return Buffer.from(file.content, 'base64')
         }
         return Buffer.from("", 'base64')
     }
@@ -51,7 +51,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
 
     isDirectory(path: string): boolean {
         for (const file of this.files) {
-            if (file.path === path && (file.content === null || file.content === ""))
+            if (this.isSamePath(file.path, path) && (file.content === null || file.content === ""))
                 return true
         }
         return false
@@ -81,7 +81,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
     writeFileSync(path: string, content: string): void {
         // If file path is exists, override content.
         for (const file of this.files) {
-            if (file.path === path) {
+            if (this.isSamePath(file.path, path)) {
                 file.content = content
                 return
             }
@@ -124,5 +124,9 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
     debug(): void {
       console.log("InMemoryFileManipulator debug");
       console.log(this.files);
+    }
+
+    isSamePath(path1: string, path2: string): boolean {
+      return path1.replace('//', '/') === path2.replace('//', '/');
     }
 }


### PR DESCRIPTION
### This PR will fix

- Drop files that doesn't have content or path name
- Change the comparison path logic.

Before this change, spear-cli will generate directory file as well. 

### この PR では以下の修正をしています

- コンテンツまたはディレクトリパスを持たないファイルを削除
- ファイルパスの比較ロジックを変更

この変更前では、spear-cli はディレクトリをファイルとして出力していました。