### PR TITLE
Support memfs.

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -44,6 +44,7 @@
     "glob": "^8.0.3",
     "html-minifier-terser": "^7.0.0-beta.0",
     "live-server": "^1.1.0",
+    "memfs": "^3.5.1",
     "node-html-parser": "^5.3.3",
     "node-watch": "^0.7.3",
     "sass": "^1.59.3",

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -63,6 +63,7 @@ export default async function inMemoryMagic(
     id: "0",
     language: "",
     path: "/lib/templates/index.html",
+    children: [],
     createdAt: new Date(),
     updatedAt: new Date(),
   })
@@ -105,7 +106,7 @@ export default async function inMemoryMagic(
     logger.log(e);
     return false;
   }
-  
+
   // Run list again to parse children of the components
   const componentsList = [] as Component[];
   for (const component of state.componentsList) {
@@ -140,9 +141,23 @@ export default async function inMemoryMagic(
     for (const targetPagePath of settings.targetPagesPathList) {
       const targetPage = state.pagesList.find(
         (page) => page.fname === targetPagePath
-      );
+      )
       if (targetPage) {
         targetPagesList.push(targetPage);
+      }
+      // Support components preview
+      const targetComponent = state.componentsList.find(
+        (component) => {
+          return "/components/" + component.fname === targetPagePath
+        }
+      )
+      if (targetComponent) {
+        targetPagesList.push({
+          fname: targetComponent.fname,
+          tagName: targetComponent.tagName,
+          node: targetComponent.node,
+          props: {},
+        });
       }
     }
     state.pagesList = targetPagesList;

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -12,7 +12,6 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
         vol.fromJSON(jsonObject, '/')
 
         const ret = fs.readdirSync('/src')
-        console.log(ret)
 
         this.files = files
         this.settingsObject = settingsObject

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -9,7 +9,6 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
     constructor(files: InMemoryFile[], settingsObject) {
         // Convert InMemoryFile array to falt JSON array.
         const jsonObject = this.extractInMemoryFilesToObject(files, "/")
-        console.log(jsonObject)
         vol.fromJSON(jsonObject, '/')
 
         const ret = fs.readdirSync('/src')

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -78,7 +78,11 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
 
     rmSync(path: string, option: any): void {
         if (!this.existsSync(path)) return
-        if (option.recursive) {
+        if (option.recursive && this.isDirectory(path)) {
+            const files = this.readdirSync(path)
+            files.forEach(file => {
+                this.rmSync(path + "/" + file, option)
+            })
             return fs.rmdirSync(path)
         }
         return fs.unlinkSync(path)

--- a/packages/spear-cli/src/interfaces/FileManipulatorInterface.ts
+++ b/packages/spear-cli/src/interfaces/FileManipulatorInterface.ts
@@ -21,6 +21,7 @@ export type InMemoryFile = {
   path: string;
   content: string;
   language: string;
+  children: InMemoryFile[];
   createdAt?: Date;
   updatedAt?: Date;
 };

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -1356,6 +1356,11 @@ fs-extra@^11.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-monkey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
+  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -2093,6 +2098,13 @@ map-visit@^1.0.0:
   integrity sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==
   dependencies:
     object-visit "^1.0.0"
+
+memfs@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.5.1.tgz#f0cd1e2bfaef58f6fe09bfb9c2288f07fea099ec"
+  integrity sha512-UWbFJKvj5k+nETdteFndTpYxdeTMox/ULeqX5k/dpaQJCCFmj5EeKv3dBcyO2xmkRAx2vppRu5dVG7SOtsGOzA==
+  dependencies:
+    fs-monkey "^1.0.3"
 
 memorystream@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
## What is this?

Previous spear implementation use the original in-memory mechanism. But this implementation has some problems:

 - Doesn't support the relative path
 - Use strict comparison of path

As result of this, this implementation is too fragile implementation. (E.g., If change the parameter path like removing top directory slash, spear has crashed.)

So this PR will use the `memfs` package which support in-memory file system like `fs`.  
https://www.npmjs.com/package/memfs

## これは何？

以前の実装はオリジナルのインメモリ実装を利用していました。この実装はいくつかの問題を抱えています。

 - 相対パスをサポートしない
 - 厳格なパスのチェックをしている

この結果、この実装はとても壊れやすい実装となっています。(例えば、パラメータパスのトップディレクトリのスラッシュを削除すると Spear はクラッシュしていました)

この PR は `memfs` という`fs` に似たインメモリファイルシステムを利用しています。  
https://www.npmjs.com/package/memfs