### PR TITLE
Support subdirectory for in-browser mode.

### DIFF
--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -316,7 +316,7 @@ function insertComponentSlot(
   }
 }
 
-export function embedAssets(state: State, assets: {[key:string]: string}, nodes: Element[], parent?: Element) {
+export function embedAssets(filepath: string, state: State, assets: {[key:string]: string}, nodes: Element[], parent?: Element) {
   const res = parse("") as Element;
 
   for (const node of nodes) {
@@ -324,9 +324,10 @@ export function embedAssets(state: State, assets: {[key:string]: string}, nodes:
     const isTextNode = node.nodeType === 3;
 
     if (!isTextNode) {
+      const currentURL = new URL(filepath, location.href);
       switch(tagName) {
         case "img": {
-          const imgURL = new URL(node.getAttribute("src"), location.href).href;
+          const imgURL = new URL(node.getAttribute("src"), currentURL).href;
           if (assets[imgURL]) {
             // Get the extension of image.
             // (We need to specify the extension for data url.)
@@ -337,7 +338,7 @@ export function embedAssets(state: State, assets: {[key:string]: string}, nodes:
           break;
         }
         case "link": {
-          const linkURL = new URL(node.getAttribute("href").replace(/\.scss$/, '.css'), location.href).href;
+          const linkURL = new URL(node.getAttribute("href").replace(/\.scss$/, '.css'), currentURL).href;
           if (assets[linkURL]) {
             // Replace link tag to style tag
             if (parent) {
@@ -349,7 +350,7 @@ export function embedAssets(state: State, assets: {[key:string]: string}, nodes:
           break;
         }
         case "script": {
-          const scriptURL = new URL(node.getAttribute("src"), location.href).href;
+          const scriptURL = new URL(node.getAttribute("src"), currentURL).href;
           if (assets[scriptURL]) {
             node.innerHTML = assets[scriptURL];
             node.removeAttribute("src");
@@ -362,6 +363,7 @@ export function embedAssets(state: State, assets: {[key:string]: string}, nodes:
 
     if (node.childNodes.length > 0) {
       node.childNodes = embedAssets(
+        filepath,
         state,
         assets,
         node.childNodes as Element[],

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -108,3 +108,9 @@ export function isParseTarget(ext: string) {
 export function needSASSBuild(ext: string) {
   return [".scss"].includes(ext)
 }
+
+export function isSamePath(path1: string, path2: string) {
+  const normalizedPath1 = path1.replace(/^\//, "");
+  const normalizedPath2 = path2.replace(/^\//, "");
+  return normalizedPath1 === normalizedPath2;
+}


### PR DESCRIPTION
## What is this change?

If the content is under the sub-directory like `sub/test.html`, Spear doesn't generate the content with `browser mode`. This PR will make the spear to support sub-directory.

## 変更点

コンテンツが `sub/test.html` のようにサブディレクトリにある場合、Spear は `browser mode` でコンテンツを生成することが出来ません。この PR ではサブディレクトリをサポートするようにしています。