### PR TITLE
Disable the SCSS of browser-mode

### DIFF
--- a/packages/spear-cli/README.md
+++ b/packages/spear-cli/README.md
@@ -4,7 +4,10 @@
 
 [![npm version](https://badge.fury.io/js/@spearly%2Fspear-cli.svg)](https://badge.fury.io/js/@spearly%2Fspear-cli)
 
-This is SSG(Static Site Generator) for Spearly.  
+Note:
+- v1.3.2 is disabling the SCSS feature because some build toolchanin has build error.(Vite)
+
+This is SSG(Static Site Generator) for Spearly.
 
 ## Usage
 

--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -2,7 +2,6 @@ import { fs, vol } from "memfs";
 import { FileManipulatorInterface, InMemoryFile } from "../interfaces/FileManipulatorInterface";
 import { SiteMapURL } from "../interfaces/MagicInterfaces";
 import { DefaultSettings } from "../interfaces/SettingsInterfaces";
-import { compileString } from "sass";
 
 export class InMemoryFileManipulator implements FileManipulatorInterface {
     files: InMemoryFile[]
@@ -100,9 +99,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
     }
 
     compileSASS(path: string):string {
-        const content = this.readFileSync(path, 'utf8')
-        const result = compileString(content)
-        return result.css.toString()
+      return ""
     }
 
     async generateSiteMap(linkList: Array<SiteMapURL>, siteURL: string): Promise<string> {


### PR DESCRIPTION
## What is this?

This change is quick fix for SCSS in `Browser-mode`.   Some build system fail the build when using the Spear.

So this patch will disable SCSS build in browser mode temporary.

I'll look into this issue on #163.

## 変更点

この修正は ブラウザモードでの SCSS　に関する緊急的な対応です。いくつかのビルドシステムで Spear を利用すると失敗するようです。

そのため、このパッチでは一時的にブラウザモードでの SCSS を無効化しています。

この問題に対しては引き続き ＃163 で調査を勧めていきます。