### PR TITLE
Fix: Use cms-core-js fix version

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/unimal-jp/spear/issues"
   },
   "dependencies": {
-    "@spearly/cms-js-core": "^1.0.10",
+    "@spearly/cms-js-core": "1.0.10",
     "@types/live-server": "^1.2.1",
     "argparse": "^2.0.1",
     "chalk": "^5.2.0",

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -124,7 +124,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@spearly/cms-js-core@^1.0.10":
+"@spearly/cms-js-core@1.0.10":
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/@spearly/cms-js-core/-/cms-js-core-1.0.10.tgz#a121cad6350cb0ef3f385dc9250e2bd714e263c9"
   integrity sha512-PqjjNFK0t5D++b1egPaAP0wXP60cZ/JhPevZ8PIK2h4iTfcuU5MFIdq5ISkg8VFrsGEFdmhzwxSR4tqTpk0wTQ==


### PR DESCRIPTION
## Changes

The package.json of `cms-core-js` has changed in this commit:   
https://github.com/unimal-jp/spear/commit/aa06cfed3c95ac286ca98e062fed0a2b62e42332#diff-7e8cbfc3d089ce41cde1d849100bed7a89e8a7f076217ede84fe5b5800962dabL6

So we need to change the import syntax..

This is hot fix using by fixed cms-core-js version.

----

## 変更点

以下のコミットで `cms-core-js` の package.json の変更をしています。  
https://github.com/unimal-jp/spear/commit/aa06cfed3c95ac286ca98e062fed0a2b62e42332#diff-7e8cbfc3d089ce41cde1d849100bed7a89e8a7f076217ede84fe5b5800962dabL6

この変更で import 文を変更する必要があります。

この修正は、固定バージョンを利用するようにしたホットフィクスです。