### PR TITLE
Add uid for generateContent  result

### DIFF
--- a/packages/spearly-cms-js-core/package-lock.json
+++ b/packages/spearly-cms-js-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/cms-js-core",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/cms-js-core",
-      "version": "1.0.10",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@spearly/sdk-js": "^1.3.0",

--- a/packages/spearly-cms-js-core/package.json
+++ b/packages/spearly-cms-js-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spearly/cms-js-core",
   "private": false,
-  "version": "1.0.10",
+  "version": "1.0.12",
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -89,7 +89,7 @@ export class SpearlyJSGenerator {
         return result
     }
 
-    async generateContent(templateHtml: string, contentType: string, contentId: string, option: GetContentOption): Promise<[html: string, patternName: string | null]> {
+    async generateContent(templateHtml: string, contentType: string, contentId: string, option: GetContentOption): Promise<[html: string, uid: string,  patternName: string | null]> {
         try {
             const result = option.previewToken
                 ? await this.client.getContentPreview(contentId, option.previewToken)
@@ -101,8 +101,9 @@ export class SpearlyJSGenerator {
                     : {}
                 );
             const replacementArray = getFieldsValuesDefinitions(result.attributes.fields.data, contentType, 2, true, this.options.dateFormatter);
+            const uid = result.attributes.publicUid;
             const patternName = result.attributes.patternName;
-            return [this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, result, contentType), patternName]
+            return [this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, result, contentType), uid, patternName]
         } catch (e: any) {
             return Promise.reject(e);
         }

--- a/packages/spearly-cms-js-core/src/spec/Generator.spec.ts
+++ b/packages/spearly-cms-js-core/src/spec/Generator.spec.ts
@@ -82,9 +82,9 @@ describe('SpearlyJSGenerator', () => {
                 });
 
                 // 変換
-                let result, patternName;
+                let result, uid, patternName;
                 try {
-                    [result, patternName] = await generator.generateContent(testData.template, testData.contentType, 'contentId', {
+                    [result, uid, patternName] = await generator.generateContent(testData.template, testData.contentType, 'contentId', {
                         patternName: 'patternName'
                     } as GetContentOption)
                 } catch(e) {


### PR DESCRIPTION
## Changes

Add uid data to result of generateContent.  
This data use for sending analytics data.  
(Caller doesn't know this data, so caller cannot send analytics data)

## 変更点

取得した UID を `generateContent` の戻り値に追加しています。  
このデータは解析情報として利用しますが、JsGenerator の呼び出し側でこの値を取得することができなかったため、追加しました。