### PR TITLE
[spear-cli] Add CMS field information into wrapped element when debugmode is enabled

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.3.5",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.5",
+  "version": "1.3.7",
   "type": "module",
   "description": "",
   "preferGlobal": true,
@@ -35,7 +35,7 @@
     "url": "https://github.com/unimal-jp/spear/issues"
   },
   "dependencies": {
-    "@spearly/cms-js-core": "1.0.10",
+    "@spearly/cms-js-core": "1.0.13",
     "@types/live-server": "^1.2.1",
     "argparse": "^2.0.1",
     "chalk": "^5.2.0",

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -25,7 +25,8 @@ export default async function inMemoryMagic(
 
   const jsGenerator = new SpearlyJSGenerator(
     settings.spearlyAuthKey,
-    settings.apiDomain
+    settings.apiDomain,
+    settings.analysysDomain || "analytics.spearly.com",
   );
   let state: State = {
     pagesList: [],

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -22,10 +22,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
     
               if (ext === ".js" || ext === ".mjs") {
                 const data = await import(
-                  files[0],
-                  files[0].indexOf("json") > -1
-                    ? { assert: { type: "json" } }
-                    : undefined
+                  files[0]
                 );
                 resolve(data.default);
               } else if (ext === ".json") {

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -13,6 +13,7 @@ export interface DefaultSettings {
   port?: number
   host?: string
   apiDomain: string,
+  analysysDomain: string,
   generateSitemap: boolean,
   siteURL: string,
   rootDir: string,

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -40,6 +40,7 @@ function initializeArgument(args: Args) {
     port: 8080,
     host: "0.0.0.0",
     apiDomain: "api.spearly.com",
+    analysysDomain: "analytics.spearly.com",
     generateSitemap: false,
     siteURL: "",
     rootDir: dirname,
@@ -59,7 +60,7 @@ async function bundle(): Promise<boolean> {
     },
   }
 
-  jsGenerator = new SpearlyJSGenerator(Settings.spearlyAuthKey, Settings.apiDomain)
+  jsGenerator = new SpearlyJSGenerator(Settings.spearlyAuthKey, Settings.apiDomain, Settings.analysysDomain)
 
   // Hook API: beforeBuild
   for (const plugin of Settings.plugins) {

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -2,7 +2,7 @@ import { Component, Element, State } from "../interfaces/MagicInterfaces";
 import { parse } from "node-html-parser";
 import mime from "mime-types";
 import { minify } from "html-minifier-terser";
-import { SpearlyJSGenerator } from "@spearly/cms-js-core"
+import { GetContentOption, SpearlyJSGenerator } from "@spearly/cms-js-core"
 import { generateAPIOptionMap } from "./util.js";
 import { SpearSettings } from "../interfaces/HookCallbackInterface";
 
@@ -60,7 +60,8 @@ export async function parseElements(state: State, nodes: Element[], jsGenerator:
         node.outerHTML,
         contentType,
         "",
-        apiOption
+        apiOption,
+        settings.debugMode
       );
       const generatedNode = parse(generatedStr) as Element;
       res.appendChild(generatedNode);
@@ -82,10 +83,12 @@ export async function parseElements(state: State, nodes: Element[], jsGenerator:
         node.setAttribute("data-spear-content-type", `{%= ${contentType}_#content_type %}`);
         node.setAttribute("data-spear-content", `{%= ${contentType}_#alias %}`);
       }
-      const generatedStr = await jsGenerator.generateContent(
+      const [generatedStr, _] = await jsGenerator.generateContent(
         node.outerHTML,
         contentType,
-        contentId
+        contentId,
+        {} as GetContentOption,
+        settings.debugMode
       );
       const generatedNode = parse(generatedStr) as Element;
       res.appendChild(generatedNode);
@@ -144,7 +147,8 @@ export async function generateAliasPagesFromPagesList(
             tagAndAliasLoopElement.innerHTML,
             contentType,
             apiOption,
-            tagFieldName
+            tagFieldName,
+            settings.debugMode
           );
           generatedContents.forEach(c => {
             tagAndAliasLoopElement.innerHTML = c.generatedHtml;
@@ -196,7 +200,9 @@ export async function generateAliasPagesFromPagesList(
             tagAndLoopElement.innerHTML,
             contentType,
             apiOption,
-            tagFieldName
+            tagFieldName,
+            "",
+            settings.debugMode
           )
           generatedLists.forEach(c => {
             tagAndLoopElement.innerHTML = c.generatedHtml;
@@ -232,7 +238,9 @@ export async function generateAliasPagesFromPagesList(
           const generatedContents = await jsGenerator.generateEachContentFromList(
             aliasLoopElement.innerHTML,
             contentType,
-            apiOption
+            apiOption,
+            "",
+            settings.debugMode
           );
           generatedContents.forEach(c => {
             aliasLoopElement.innerHTML = c.generatedHtml;
@@ -277,7 +285,9 @@ export async function generateAliasPagesFromPagesList(
       const generatedContents = await jsGenerator.generateEachContentFromList(
         targetElement.innerHTML,
         contentType,
-        apiOption
+        apiOption,
+        "",
+        settings.debugMode
       );
       generatedContents.forEach((c) => {
         targetElement.innerHTML = c.generatedHtml;

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -124,20 +124,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@spearly/cms-js-core@1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@spearly/cms-js-core/-/cms-js-core-1.0.10.tgz#a121cad6350cb0ef3f385dc9250e2bd714e263c9"
-  integrity sha512-PqjjNFK0t5D++b1egPaAP0wXP60cZ/JhPevZ8PIK2h4iTfcuU5MFIdq5ISkg8VFrsGEFdmhzwxSR4tqTpk0wTQ==
+"@spearly/cms-js-core@file:../spearly-cms-js-core":
+  version "1.0.12"
   dependencies:
-    "@spearly/sdk-js" "^1.0.0"
+    "@spearly/sdk-js" "^1.3.1"
     node-html-parser "^6.1.4"
 
-"@spearly/sdk-js@^1.0.0":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@spearly/sdk-js/-/sdk-js-1.1.2.tgz#69bed5526e44c3c080e0aab7dadb97b77edc9e74"
-  integrity sha512-5lGTOXuFgguNOn9XBD2YxwYz3Yzyi8pX1dDRLc32CdkCx3NLs0SGM1G1KBNOve+SVV9GqkZPfdmCzYvlpsvHOg==
+"@spearly/sdk-js@^1.3.1":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@spearly/sdk-js/-/sdk-js-1.3.3.tgz#e34f13e843bb7ac1b5a5f77335f651410c616c9b"
+  integrity sha512-ljBaeBnJw9RlU3OlgDKocf5fD4Le4wSGzU5DZ9dRfVkwjNCfeulAQyPlKwthmv3Dn1LfHTReepdpM5ydYCfsZQ==
   dependencies:
     axios "^1.3.4"
+    js-cookie "^3.0.5"
+    uuid "^9.0.0"
 
 "@types/argparse@^2.0.10":
   version "2.0.10"
@@ -1996,6 +1996,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3358,6 +3363,11 @@ uuid@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
## Changes:

This change is related with #171 .  
Spear (spear-cli) support the debug mode which injecting the CMS's field identifier into wrapped element.

If we have the following original source code, Spear will insert <span> element into outer of embed syntax.

```
<div>
 <p>Title is {%= news_title %}</p>
</div>
```

generated result:

```
<div>
  <p>Title is <span>news title no.1</span></p>
</div>
```