### PR TITLE
Fix: Use sass package / Use relative path of asset

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -49,7 +49,6 @@
     "node-html-parser": "^5.3.3",
     "node-watch": "^0.7.3",
     "sass": "^1.63.6",
-    "scss-parser": "^1.0.6",
     "sitemap": "^7.1.1",
     "yaml": "^2.2.1"
   },

--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -2,7 +2,7 @@ import { fs, vol } from "memfs";
 import { FileManipulatorInterface, InMemoryFile } from "../interfaces/FileManipulatorInterface";
 import { SiteMapURL } from "../interfaces/MagicInterfaces";
 import { DefaultSettings } from "../interfaces/SettingsInterfaces";
-import { parse, stringify } from 'scss-parser';
+import { compileString } from "sass"
 
 export class InMemoryFileManipulator implements FileManipulatorInterface {
     files: InMemoryFile[]
@@ -101,9 +101,9 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
 
     // Use Salesforce Light SCSS parser on in-browser mode.
     compileSASS(path: string):string {
-      const cssFile = this.readFileSync(path, 'utf8');
-      const ast = parse(cssFile);
-      return stringify(ast);
+      const fileContent = fs.readFileSync(path, 'utf8');
+      const result = compileString(fileContent.toString());
+      return result.css;
     }
 
     async generateSiteMap(linkList: Array<SiteMapURL>, siteURL: string): Promise<string> {

--- a/packages/spear-cli/src/utils/file.ts
+++ b/packages/spear-cli/src/utils/file.ts
@@ -183,14 +183,14 @@ export class FileUtil {
       } else if (needSASSBuild(ext)) {
         const css = this.manipulator.compileSASS(filePath);
         state.out.assetsFiles.push({
-          filePath: `${dirPath}/${fname}.css`,
+          filePath: `${relatePath}/${fname}.css`,
           rawData: Buffer.from(css),
         });
         continue;
       } else if (!isParseTarget(ext)) {
         const rawData = this.manipulator.readFileSyncAsBuffer(filePath);
         state.out.assetsFiles.push({
-          filePath: `${dirPath}/${file}`,
+          filePath: `${relatePath}/${file}`,
           rawData,
         });
         continue;

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -124,8 +124,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@spearly/cms-js-core@file:../spearly-cms-js-core":
-  version "1.0.12"
+"@spearly/cms-js-core@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@spearly/cms-js-core/-/cms-js-core-1.0.13.tgz#0a56651b5fdfdb31554be0a3dd60923fcea4b6a0"
+  integrity sha512-YlLnKWF8rirq2McnxpO72MoaLi8hfM8qpfXepwLQxNGw+LxMuMrgvgAEkvm3LJ+oWosEZsFfm6k3T2VscIV1LA==
   dependencies:
     "@spearly/sdk-js" "^1.3.1"
     node-html-parser "^6.1.4"
@@ -1730,13 +1732,6 @@ internal-slot@^1.0.5:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-invariant@2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
-
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -2001,11 +1996,6 @@ js-cookie@^3.0.5:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
-"js-tokens@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -2109,18 +2099,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash@4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -2821,14 +2799,6 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-scss-parser@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/scss-parser/-/scss-parser-1.0.6.tgz#cd1ba01ee32db19322c8df2badd26da8f166b1c1"
-  integrity sha512-SH3TaoaJFzfAtqs3eG1j5IuHJkeEW5rKUPIjIN+ZorLAyJLHItQGnsgwHk76v25GtLtpT9IqfAcqK4vFWdiw+w==
-  dependencies:
-    invariant "2.2.4"
-    lodash "4.17.21"
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.7.1:
   version "5.7.1"


### PR DESCRIPTION
## Changes:

This PR will fix the following issue:

1. Use SASS Packages

In #166, spear use the `scss-parser` package due to issue of `sass` package. However I confirmed that we can use this package, so in this PR will use `sass` package.

2. Use relative path of assets.

#158 introduced the embed assets feature. In this change, change the assets output directory. But we doesn't need to change it. This PR will fix it.

