### PR TITLE
[cms-js-core] Add date-only option to calendar field

### DIFF
--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -3,13 +3,15 @@ import { FieldTypeTags, SpearlyApiClient } from '@spearly/sdk-js';
 import getFieldsValuesDefinitions, { generateGetParamsFromAPIOptions, getCustomDateString, ReplaceDefinition } from './Utils.js'
 import type { AnalyticsPostParams, Content } from '@spearly/sdk-js'
 
+export type DateFormatter = (date: Date, dateOnly?: boolean) => string
+
 export type SpearlyJSGeneratorOption = {
     linkBaseUrl: string | undefined;
-    dateFormatter: Function | undefined;
+    dateFormatter: DateFormatter | undefined;
 }
 type SpearlyJSGeneratorInternalOption = {
     linkBaseUrl: string;
-    dateFormatter: Function;
+    dateFormatter: DateFormatter;
 }
 export type GetContentOption = {
     patternName: string,
@@ -35,8 +37,8 @@ export class SpearlyJSGenerator {
         this.client = new SpearlyApiClient(apiKey, domain, analyticsDomain)
         this.options = {
             linkBaseUrl: options?.linkBaseUrl || "",
-            dateFormatter:  options?.dateFormatter || function japaneseDateFormatter(date: Date) {
-                return getCustomDateString("YYYY年MM月DD日 hh時mm分ss秒", date)
+            dateFormatter:  options?.dateFormatter || function japaneseDateFormatter(date: Date, dateOnly?: boolean) {
+                return getCustomDateString(`YYYY年MM月DD日${!dateOnly ? " hh時mm分ss秒" : ""}`, date)
             }
         }
     }

--- a/packages/spearly-cms-js-core/src/Utils.ts
+++ b/packages/spearly-cms-js-core/src/Utils.ts
@@ -72,6 +72,11 @@ export default function getFieldsValuesDefinitions(
             definitionString: "{%= " + prefix + "_" + key + " %}",
             fieldValue: insertDebugAttribute(dateFormatter(new Date(field.attributes.value)), field.attributes.identifier, insertDebugInfo)
         })
+
+        replaceDefinitions.push({
+          definitionString: "{%= " + prefix + "_" + key + "_#date_only %}",
+          fieldValue: insertDebugAttribute(dateFormatter(new Date(field.attributes.value), true), field.attributes.identifier, insertDebugInfo)
+      })
       } else if (isTagType(field)) {
         // TODO: タグの取り扱いを今後変更する必要がある
         replaceDefinitions.push({

--- a/packages/spearly-cms-js-core/src/spec/Generator.spec.ts
+++ b/packages/spearly-cms-js-core/src/spec/Generator.spec.ts
@@ -49,6 +49,16 @@ const convertTestData = [
         expected: "<date>Mon Dec 05 2022 11:22:33 GMT+0900 (Japan Standard Time)</date>"
     },
     {
+        testName: "Date only",
+        template: "<date>{%= blog_date_#date_only %}</date>",
+        options: {} as unknown as SpearlyJSGeneratorOption,
+        contentType: "blog",
+        mockData: generateServerContent([
+            { identifier: "date", inputType: "calendar", value: "2022-12-05 11:22:33" }
+        ]),
+        expected: "<date>2022年12月05日</date>"
+    },
+    {
         testName: "Custom date formatter",
         template: "<p>{%= blog_#alias %}</p>",
         options: {} as unknown as SpearlyJSGeneratorOption,


### PR DESCRIPTION
## Changes:
Add `date_only` option that can be set if users don't want to display dates in calendar fields.

## Example:

```html
<time>{%= blog_date_#date_only %}</time>
```
↓
```html
<time>2022-06-06</time>
```