### PR TITLE
Add content type parameter when generating conent

### DIFF
--- a/packages/spearly-cms-js-core/package-lock.json
+++ b/packages/spearly-cms-js-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/cms-js-core",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/cms-js-core",
-      "version": "1.0.13",
+      "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
         "@spearly/sdk-js": "^1.3.0",

--- a/packages/spearly-cms-js-core/package.json
+++ b/packages/spearly-cms-js-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spearly/cms-js-core",
   "private": false,
-  "version": "1.0.13",
+  "version": "1.0.15",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/unimal-jp/spear#readme",
   "dependencies": {
     "node-html-parser": "^6.1.4",
-    "@spearly/sdk-js": "^1.3.1"
+    "@spearly/sdk-js": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.3",

--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -94,8 +94,8 @@ export class SpearlyJSGenerator {
     async generateContent(templateHtml: string, contentType: string, contentId: string, option: GetContentOption, insertDebugInfo: boolean): Promise<[html: string, uid:string, patternName: string | null]> {
         try {
             const result = option.previewToken
-                ? await this.client.getContentPreview(contentId, option.previewToken)
-                : await this.client.getContent(contentId, 
+                ? await this.client.getContentPreview(contentType, contentId, option.previewToken)
+                : await this.client.getContent(contentType, contentId,
                     option.patternName
                     ? {
                         patternName: option.patternName

--- a/packages/spearly-cms-js-core/yarn.lock
+++ b/packages/spearly-cms-js-core/yarn.lock
@@ -579,10 +579,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@spearly/sdk-js@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@spearly/sdk-js/-/sdk-js-1.3.1.tgz#fcd86a34c241a1e1a8ec8b93858d3b579504ee94"
-  integrity sha512-dxhAcKc/3QXDx8RYEBoSavna9MQSESX4kNyPG1rFZyZL22dHCHHPkMUu8jhNhm4c96LHa5A34uYSagEcrohzOw==
+"@spearly/sdk-js@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spearly/sdk-js/-/sdk-js-2.0.0.tgz#164fc82379028cf14d4d32f5908863850983cf2a"
+  integrity sha512-C4UDdu0tZZcE4/0Qz8MO5w6ZTTrvO/BvJNkoUpb5CxlJRXY7Rs6lhuLWQkzyBedgzcE5PttKQXZ7YG2a58MLEg==
   dependencies:
     axios "^1.3.4"
     js-cookie "^3.0.5"


### PR DESCRIPTION
## Changes

The spearly sdk-js changed the getContent parameter:
So this PR will pass the content type id to spearly sdk-js (https://github.com/unimal-jp/spearly-sdk-js/pull/85)

## 変更点

`@spearly/sdk-js` では、`getContent` のパラメター変更をしています。  
そのため、この PR はコンテントタイプIDを sdk-js に渡すように修正しています。(https://github.com/unimal-jp/spearly-sdk-js/pull/85)