### PR TITLE
Introduce the cross origin isolation mode

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.3.8",
+      "version": "1.3.9",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -12,6 +12,7 @@ export interface DefaultSettings {
   spearlyAuthKey?: string
   port?: number
   host?: string
+  crossOriginIsonation: boolean,
   apiDomain: string,
   analysysDomain: string,
   generateSitemap: boolean,

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -12,7 +12,7 @@ export interface DefaultSettings {
   spearlyAuthKey?: string
   port?: number
   host?: string
-  crossOriginIsonation: boolean,
+  crossOriginIsolation: boolean,
   apiDomain: string,
   analysysDomain: string,
   generateSitemap: boolean,

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -39,6 +39,7 @@ function initializeArgument(args: Args) {
     spearlyAuthKey: "",
     port: 8080,
     host: "0.0.0.0",
+    crossOriginIsonation: false,
     apiDomain: "api.spearly.com",
     analysysDomain: "analytics.spearly.com",
     generateSitemap: false,
@@ -228,6 +229,16 @@ export default async function magic(args: Args): Promise<boolean> {
       wait: 1000,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       logLevel: 0 as any,
+      middleware:
+        Settings.crossOriginIsonation
+          ? [
+              function (req: any, res: any, next: any) {
+                res.setHeader("Cross-Origin-Embedder-Policy", "credentialless")
+                res.setHeader("Cross-Origin-Opener-Policy", "same-origin")
+                next()
+              }
+          ]
+          : []
     }
 
     liveServer.start(params)

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -39,7 +39,7 @@ function initializeArgument(args: Args) {
     spearlyAuthKey: "",
     port: 8080,
     host: "0.0.0.0",
-    crossOriginIsonation: false,
+    crossOriginIsolation: false,
     apiDomain: "api.spearly.com",
     analysysDomain: "analytics.spearly.com",
     generateSitemap: false,
@@ -230,7 +230,7 @@ export default async function magic(args: Args): Promise<boolean> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       logLevel: 0 as any,
       middleware:
-        Settings.crossOriginIsonation
+        Settings.crossOriginIsolation
           ? [
               function (req: any, res: any, next: any) {
                 res.setHeader("Cross-Origin-Embedder-Policy", "credentialless")


### PR DESCRIPTION
## Background

Recently, WASM and SharedArrayBuffer technologies enable running npm package on browser like Web Containers[1].  
This technologies are allowed under "Cross Origin Isolation" environment[2]. I tried spear-cli with Web Containers, then I found that `live-server` doesn't send the cross origin response headers.   
So we need to support these header when running dev mode on Web Containers.

[1] https://webcontainers.io/
[2] https://web.dev/why-coop-coep/
[3] https://blog.agektmr.com/2021/11/cross-origin-isolation.html (Japanese only)

## Changes

Add `Cross-Origin-Embedder-Poilicy` and `Cross-Origin-Opener-Policy` into settings.  

If user want to use this configuration, user should write settings into `spear.config.mjs`:

```
export default {
  "spearlyAuthKey": "--------------",
  "projectName": "test",
  "generateSitemap": false,
  "crossOriginIsolation": true,
};
```


------


## 背景

最近、WASM や SharedArrayBuffer 技術により、Web Containers[1] のように npm パッケージをブラウザ上でどうさせることが可能になってきました。  
この技術は Cross Origin Isolation 環境で許可されています[2][3]。試しに spear-cli を Web Containers で動かしてみた所、 `live-server` が必要な Cross Origin レスポンスヘッダーを付与していないことがわかりました。  
そのため、Web Containers で動作させるためには、これらのヘッダーをサポートする必要があります。

[1] https://webcontainers.io/
[2] https://web.dev/why-coop-coep/
[3] https://blog.agektmr.com/2021/11/cross-origin-isolation.html


## 変更点

「Cross-Origin-Embedder-Policy」と「Cross-Origin-Operner-Policy」を設定に追加しています。

もし設定を利用したい場合は、以下のように `spear.config.mjs` へ設定を追加する必要があります。

```
export default {
  "spearlyAuthKey": "--------------",
  "projectName": "test",
  "generateSitemap": false,
  "crossOriginIsolation": true,
};
```