### PR TITLE
Support specifying configuration file

### DIFF
--- a/packages/spear-cli/src/index.ts
+++ b/packages/spear-cli/src/index.ts
@@ -21,6 +21,7 @@ parser.add_argument("-p", "--port", { required: false, type: "int" })
 parser.add_argument("action", { help: "Action: create" })
 parser.add_argument("projectName", { help: "Project name", nargs: "?" })
 parser.add_argument("-s", "--src", { help: "Specify source directory. "})
+parser.add_argument("-f", "--file", { help: "Specify configuration settings file. (default is spear.config)"})
 
 const args = parser.parse_args()
 

--- a/packages/spear-cli/src/interfaces/ArgsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/ArgsInterfaces.ts
@@ -3,4 +3,5 @@ export interface Args {
   projectName: string
   port: number
   src: string
+  file: string
 }

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -28,7 +28,7 @@ function initializeArgument(args: Args) {
   }
   settings = {
     projectName: "Spear CLI",
-    settingsFile: "spear.config",
+    settingsFile: args.file || "spear.config",
     pagesFolder: `${dirname}/src/pages`,
     componentsFolder: [ `${dirname}/src/components` ],
     srcDir: [ `${dirname}/src` ],


### PR DESCRIPTION
## What is this?

It's change that making spear to be changeable the spear.config.mjs.

The spear documentation need this change, because the spear document project want to switch build context by language.  

For example documentation, the english page will use the data of english directory:  
https://github.com/mantaroh/spear-doc/blob/main/spear.config-en.mjs

Otherwise, Japanese page will use the data of japanese directory:
https://github.com/mantaroh/spear-doc/blob/main/spear.config-jp.mjs

## 変更点

これは Spear の設定ファイルを変更可能にする変更です。

Spear のドキュメントでは言語毎にビルドコンテキストを切り替える必要があり、この変更可能な設定ファイルが必要です。

例えば、英語のページでは英語のデータからページを生成しています。  
https://github.com/mantaroh/spear-doc/blob/main/spear.config-en.mjs

一方で日本語ページは日本語データを利用して生成しています。  
https://github.com/mantaroh/spear-doc/blob/main/spear.config-jp.mjs

