### PR TITLE
Inject debug information as own element attribute when embed sytanx is in the attribute value.

### DIFF
--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -76,7 +76,7 @@ export class SpearlyJSGenerator {
                 // I.g., add data-spear attribute to the parent element.
                 result = result
                     .split(`"${r.definitionString}"`).join(`"${r.fieldValue}" data-spear="${contentType}--${contentId}--${fieldId}"`)
-                    .split(`'${r.definitionString}'`).join(`"${r.fieldValue}" data-spear="${contentType}--${contentId}--${fieldId}"`)
+                    .split(`'${r.definitionString}'`).join(`'${r.fieldValue}' data-spear='${contentType}--${contentId}--${fieldId}'`)
                     .split(r.definitionString).join(`<span data-spear="${contentType}--${contentId}--${fieldId}">${r.fieldValue}</span>`)
             } else {
                 result = result.split(r.definitionString).join(r.fieldValue)

--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -64,9 +64,13 @@ export class SpearlyJSGenerator {
         this.client = fakeClient;
     }
 
-    convertFromFieldsValueDefinitions(templateHtml: string, replacementArray: ReplaceDefinition[], content: Content, contentType: string): string {
+    convertFromFieldsValueDefinitions(templateHtml: string, replacementArray: ReplaceDefinition[], content: Content, contentType: string, insertDebugInfo: boolean): string {
         let result = templateHtml
         replacementArray.forEach(r => {
+            // TODO: 
+            if (insertDebugInfo) {
+
+            }
             result = result.split(r.definitionString).join(r.fieldValue)
 
         })
@@ -123,10 +127,10 @@ export class SpearlyJSGenerator {
                         }
                         : {}
                 );
-            const replacementArray = getFieldsValuesDefinitions(result.attributes.fields.data, contentType, 2, true, this.options.dateFormatter, insertDebugInfo);
+            const replacementArray = getFieldsValuesDefinitions(result.attributes.fields.data, contentType, 2, true, this.options.dateFormatter);
             const uid = result.attributes.publicUid;
             const patternName = result.attributes.patternName;
-            return [this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, result, contentType), uid, patternName]
+            return [this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, result, contentType, insertDebugInfo), uid, patternName]
         } catch (e: any) {
             return Promise.reject(e);
         }
@@ -174,8 +178,8 @@ export class SpearlyJSGenerator {
             const result = await this.client.getList(contentType, generateGetParamsFromAPIOptions(apiOptions))
             let resultHtml = ""
             result.data.forEach(c => {
-                const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, variableName || contentType, 2, true, this.options.dateFormatter, insertDebugInfo);
-                resultHtml += this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType)
+                const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, variableName || contentType, 2, true, this.options.dateFormatter);
+                resultHtml += this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType, insertDebugInfo)
             })
 
             return resultHtml
@@ -211,13 +215,13 @@ export class SpearlyJSGenerator {
                 })
                 let resultHtml = ""
                 targetContents.forEach(c => {
-                    const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, variableName || contentType, 2, true, this.options.dateFormatter, insertDebugInfo);
+                    const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, variableName || contentType, 2, true, this.options.dateFormatter);
                     // Special replacement string
                     replacementArray.push({
                         definitionString: `{%= ${contentType}_#tag %}`,
                         fieldValue: tag,
                     })
-                    resultHtml += this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType)
+                    resultHtml += this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType, insertDebugInfo)
                 })
                 contentsByTag.push({
                     generatedHtml: resultHtml,
@@ -235,7 +239,7 @@ export class SpearlyJSGenerator {
             const generatedContents: GeneratedContent[] = []
             const result = await this.client.getList(contentType, generateGetParamsFromAPIOptions(apiOptions))
             result.data.forEach(c => {
-                const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, contentType, 2, true, this.options.dateFormatter, insertDebugInfo)
+                const replacementArray = getFieldsValuesDefinitions(c.attributes.fields.data, contentType, 2, true, this.options.dateFormatter)
                 const tags = c.attributes.fields.data.filter(field => field.attributes.identifier === tagFieldName)
                 let tag: string[] = []
                 if (tags && tags.length > 0 && Array.isArray(tags[0].attributes.value)) {
@@ -244,7 +248,7 @@ export class SpearlyJSGenerator {
 
                 generatedContents.push({
                     alias: c.attributes.contentAlias || c.attributes.publicUid,
-                    generatedHtml: this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType),
+                    generatedHtml: this.convertFromFieldsValueDefinitions(templateHtml, replacementArray, c, contentType, insertDebugInfo),
                     tag
                 })
             });

--- a/packages/spearly-cms-js-core/src/Generator.ts
+++ b/packages/spearly-cms-js-core/src/Generator.ts
@@ -67,12 +67,20 @@ export class SpearlyJSGenerator {
     convertFromFieldsValueDefinitions(templateHtml: string, replacementArray: ReplaceDefinition[], content: Content, contentType: string, insertDebugInfo: boolean): string {
         let result = templateHtml
         replacementArray.forEach(r => {
-            // TODO: 
+            // e.g.,<span data-spear="${contentTypeId}--${contentId}--${fieldId}">${value}</span>
             if (insertDebugInfo) {
-
+                const contentId = content.attributes.contentAlias || content.attributes.publicUid
+                const fieldId = r.debugInfo?.fieldId || ""
+                // If matching the "${r.definitionString}" or '${r.definitionString}', replace it to
+                // `"${r.fieldValue}" data-spear="${contentTypeId}--${contentId}--${fieldId}"`.
+                // I.g., add data-spear attribute to the parent element.
+                result = result
+                    .split(`"${r.definitionString}"`).join(`"${r.fieldValue}" data-spear="${contentType}--${contentId}--${fieldId}"`)
+                    .split(`'${r.definitionString}'`).join(`"${r.fieldValue}" data-spear="${contentType}--${contentId}--${fieldId}"`)
+                    .split(r.definitionString).join(`<span data-spear="${contentType}--${contentId}--${fieldId}">${r.fieldValue}</span>`)
+            } else {
+                result = result.split(r.definitionString).join(r.fieldValue)
             }
-            result = result.split(r.definitionString).join(r.fieldValue)
-
         })
 
         // Especially convert for {%= <ContentType>_#url %} and {%= <ContentType>_#link $}

--- a/packages/spearly-cms-js-core/src/Utils.ts
+++ b/packages/spearly-cms-js-core/src/Utils.ts
@@ -187,14 +187,6 @@ const getEscapedStringRichText = (str: string): string => {
     return ""
 }
 
-// wrap the targetHTML by span tag with debug attribute(value is fieldId)
-const insertDebugAttribute = (targetHTML: string, contentTypeId: string, contentId: string, fieldId: string, insertDebugInfo: boolean): string => {
-  return insertDebugInfo 
-    ? `<span data-spear-content="${contentTypeId}--${contentId}--${fieldId}">${targetHTML}</span>`
-    : targetHTML
-}
-
-
 export function getCustomDateString(suffix: string, date: Date): string {
     let numberFormat =
         new Intl.NumberFormat('en-US',

--- a/packages/spearly-cms-js-core/src/Utils.ts
+++ b/packages/spearly-cms-js-core/src/Utils.ts
@@ -30,6 +30,9 @@ const isContentType = (fieldType: FieldTypeAll): fieldType is FieldTypeContentTy
 export declare type ReplaceDefinition = {
     definitionString: string;
     fieldValue: string;
+    debugInfo?: {
+      fieldId: string;
+    };
 };
 
 export default function getFieldsValuesDefinitions(
@@ -38,7 +41,6 @@ export default function getFieldsValuesDefinitions(
     depth = 0,
     disableContentType = false,
     dateFormatter: Function,
-    insertDebugInfo: boolean
 ): ReplaceDefinition[] {
     if (depth >= 3) {
       return [];
@@ -50,61 +52,94 @@ export default function getFieldsValuesDefinitions(
       if (isTextType(field)) {
         replaceDefinitions.push({
           definitionString: "{%= " + prefix + "_" + key + " %}",
-          fieldValue: insertDebugAttribute(getEscapedString(field.attributes.value), field.attributes.identifier, insertDebugInfo)
+          fieldValue: getEscapedString(field.attributes.value),
+          debugInfo: {
+            fieldId: field.attributes.identifier
+          }
         });
       } else if (isNumberType(field)) {
         replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + " %}",
-            fieldValue: insertDebugAttribute(field.attributes.value.toString(), field.attributes.identifier, insertDebugInfo)
+            fieldValue: field.attributes.value.toString(),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
         })
       } else if (isRichTextType(field)) {
         replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + " %}",
-            fieldValue: insertDebugAttribute(getEscapedStringRichText(field.attributes.value), field.attributes.identifier, insertDebugInfo)
+            fieldValue: getEscapedStringRichText(field.attributes.value),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
         })
       } else if (isImageType(field)) {
         replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + " %}",
-            fieldValue: insertDebugAttribute(getEscapedString(field.attributes.value), field.attributes.identifier, insertDebugInfo)
+            fieldValue: getEscapedString(field.attributes.value),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
         })
       } else if (isCalendarType(field)) {
         replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + " %}",
-            fieldValue: insertDebugAttribute(dateFormatter(new Date(field.attributes.value)), field.attributes.identifier, insertDebugInfo)
+            fieldValue: dateFormatter(new Date(field.attributes.value)),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
         })
 
         replaceDefinitions.push({
           definitionString: "{%= " + prefix + "_" + key + "_#date_only %}",
-          fieldValue: insertDebugAttribute(dateFormatter(new Date(field.attributes.value), true), field.attributes.identifier, insertDebugInfo)
-      })
+          fieldValue: dateFormatter(new Date(field.attributes.value), true),
+          debugInfo: {
+            fieldId: field.attributes.identifier
+          }
+        })
       } else if (isTagType(field)) {
         // TODO: タグの取り扱いを今後変更する必要がある
         replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + " %}",
-            fieldValue: insertDebugAttribute(getEscapedString(field.attributes.value.join(',')), field.attributes.identifier, insertDebugInfo)
+            fieldValue: getEscapedString(field.attributes.value.join(',')),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
         })
       } else if (isMapType(field)) {
         const value = field.attributes.value
         if (value.address) {
           replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + "_#address %}",
-            fieldValue: insertDebugAttribute(encodeURIComponent(getEscapedString(value.address)), field.attributes.identifier, insertDebugInfo)
+            fieldValue: encodeURIComponent(getEscapedString(value.address)),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
           });
           replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + "_#address_decoded %}",
-            fieldValue: insertDebugAttribute(getEscapedString(value.address), field.attributes.identifier, insertDebugInfo)
+            fieldValue: getEscapedString(value.address),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
           });
         }
         if (value.latitude) {
           replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + "_#latitude %}",
-            fieldValue: insertDebugAttribute(value.latitude.toString(), field.attributes.identifier, insertDebugInfo)
+            fieldValue: value.latitude.toString(),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
           });
         }
         if (value.longitude) {
           replaceDefinitions.push({
             definitionString: "{%= " + prefix + "_" + key + "_#longitude %}",
-            fieldValue: insertDebugAttribute(value.longitude.toString(), field.attributes.identifier, insertDebugInfo)
+            fieldValue: value.longitude.toString(),
+            debugInfo: {
+              fieldId: field.attributes.identifier
+            }
           });
         }
       } else if (isContentType(field)) {
@@ -116,8 +151,7 @@ export default function getFieldsValuesDefinitions(
                     `${prefix}_${key}`,
                     depth++,
                     disableContentType,
-                    dateFormatter,
-                    insertDebugInfo
+                    dateFormatter
                 ));
         } catch(e) {
             console.log('Spearly found the non value of reference type', e)
@@ -154,9 +188,9 @@ const getEscapedStringRichText = (str: string): string => {
 }
 
 // wrap the targetHTML by span tag with debug attribute(value is fieldId)
-const insertDebugAttribute = (targetHTML: string, fieldId: string, insertDebugInfo: boolean): string => {
+const insertDebugAttribute = (targetHTML: string, contentTypeId: string, contentId: string, fieldId: string, insertDebugInfo: boolean): string => {
   return insertDebugInfo 
-    ? `<span data-spear-content-field="${fieldId}">${targetHTML}</span>`
+    ? `<span data-spear-content="${contentTypeId}--${contentId}--${fieldId}">${targetHTML}</span>`
     : targetHTML
 }
 


### PR DESCRIPTION
## Changes

This PR will inject the debug information as own element's attribute when the embed syntax is in the attribute value.

The debug feature is introduced by #167 . This changes will inject `<span>` tag into generated HTML:

If we have `<div cms-loop cms-content-type="a">{%= a_title %}</div>`,   
generated HTML is `<div><span data-spear-content-field="title">Title Desu</span></div>`.

Almost cases might work fine for this feature, however `<img>` or `<time>` element can't work well since we put embed syntax to attribute value:

```html
<div cms-loop cms-content-type="a">
  <img src="{%= a_image %}">
</div>
```

An above code will be generated the following w/ debug info:

```html
<div>
  <img src="<span data-spear-content-field="image">https://path/to/image</span>">
</div>
```

This is HTML Syntax error.  As discussed on https://github.com/unimal-jp/spear/issues/156#issuecomment-1695535763, we should inject debug infomation as own element's attribute when embed string is in the attribute value.


-----

## 変更点

この PR は埋め込み文字列が属性の値にある場合、デバッグ情報をその属性を持つ要素に追加します。

デバッグ機能は #167 で有効になりました。この変更は生成された HTML に `<span>` タグを注入すると言ったものでした。

もし `<div cms-loop cms-content-type="a">{%= a_title %}</div>` という文字列があった場合、  
生成される HTML は `<div><span data-spear-content-field="title">Title Desu</span></div>` となります。

ほとんどのケースで上手く動きますが、 `<img>` や `<time>` と言った要素では埋め込み文字列を属性の値として入れるため上手く動作しませんでした。

```html
<div cms-loop cms-content-type="a">
  <img src="{%= a_image %}">
</div>
```

上記サンプルはデバッグ機能で以下のように生成されます。

```html
<div>
  <img src="<span data-spear-content-field="image">https://path/to/image</span>">
</div>
```

これは HTML の文法エラーです。https://github.com/unimal-jp/spear/issues/156#issuecomment-1695535763 で話し合ったとおり、その属性を持つ要素に対してデバッグ情報を挿入するべきです。
