### PR TITLE
Wait for finishing the magic process in main().

### DIFF
--- a/packages/spear-cli/src/index.ts
+++ b/packages/spear-cli/src/index.ts
@@ -26,8 +26,10 @@ parser.add_argument("-f", "--file", { help: "Specify configuration settings file
 const args = parser.parse_args()
 
 if (args.action === "watch" || args.action === "build") {
-  if (!magic(args)) {
-    // Notify caller to magic fail.
-    process.exit(1);
-  }
+  magic(args).then(result => {
+    if (!result) {
+      // Notify caller to magic fail.
+      process.exit(1);
+    }
+  });
 }


### PR DESCRIPTION
## What is this?

This fix will wait for finishing the magic process in main() function.  
Previous implementation doesn't wait for it, so return exit 0 always.

https://github.com/unimal-jp/spear/blob/c0a2544c09bd72f9e84694678bca6e395005086c/packages/spear-cli/src/index.ts#L29

## これは何？

メインの関数で magic プロセスの終了を待つようにしています。  
今までの実装だと、その処理を待たずに常に 0 を返していました。

https://github.com/unimal-jp/spear/blob/c0a2544c09bd72f9e84694678bca6e395005086c/packages/spear-cli/src/index.ts#L29