### PR TITLE
:adhesive_bandage: fix ignore JetBrains IDE setting / JetBrains IDE の設定ファイルをgitの管理対象外にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ asd
 .vscode/*
 !.vscode/extensions.json
 *.tsbuildinfo
+
+.idea


### PR DESCRIPTION
## Overview

- add JetBrains IDE setting files to `.gitignore`.

## 概要

- JetBrains IDE の設定ファイルをgitの管理対象外に追加しました