### PR TITLE
:bug: fix cannot compile sass when using `@use` / `@forward`  - `@use` / `@forward` を使うと sass のコンパイルに失敗する

### DIFF
--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -52,7 +52,7 @@
     "mime-types": "^2.1.35",
     "node-html-parser": "^5.3.3",
     "node-watch": "^0.7.3",
-    "sass": "^1.63.6",
+    "sass": "^1.69.2",
     "sitemap": "^7.1.1",
     "yaml": "^2.2.1"
   },

--- a/packages/spear-cli/src/browser/InMemoryMagic.ts
+++ b/packages/spear-cli/src/browser/InMemoryMagic.ts
@@ -69,7 +69,7 @@ export default async function inMemoryMagic(
     createdAt: new Date(),
     updatedAt: new Date(),
   })
-  const fileUtil = new FileUtil(new InMemoryFileManipulator(inputFiles, settings), logger);
+  const fileUtil = new FileUtil(new InMemoryFileManipulator(inputFiles, settings), logger, true);
 
   // Hook API: beforeBuild
   for (const plugin of settings.plugins) {
@@ -211,7 +211,7 @@ export default async function inMemoryMagic(
   // Dump pages
   await fileUtil.dumpPages(state, "/lib", settings);
   fileUtil.manipulator.rmSync("/lib", { recursive: true });
-  
+
   // Hook API: bundle
   for (const plugin of settings.plugins) {
     if (plugin.bundle) {

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -3,7 +3,7 @@ import glob from "glob";
 import path from "path";
 import { parse as yamlParse } from "yaml";
 import { FileManipulatorInterface } from "../interfaces/FileManipulatorInterface";
-import sass from "sass"
+import * as sass from "sass"
 import { SiteMapURL } from "../interfaces/MagicInterfaces";
 import { SitemapStream, streamToPromise } from "sitemap";
 import { Readable } from "stream";
@@ -16,10 +16,10 @@ export class LocalFileManipulator implements FileManipulatorInterface {
               reject(er);
               return;
             }
-    
+
             if (files.length > 0) {
               const ext = path.extname(files[0]);
-    
+
               if (ext === ".js" || ext === ".mjs") {
                 const data = await import(
                   files[0]

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -178,7 +178,7 @@ export async function generateAliasPagesFromPagesList(
             }
           })
         } else {
-          // In this case, target file doesn't have [alias] path. 
+          // In this case, target file doesn't have [alias] path.
           throw new Error(`You specified the cms-tag-loop attribute in ${page.fname}. However, this path doesn't include [tags] directory.`);
         }
       } else if (tagAndLoopElement && !tagAndLoopElement.getAttribute("cms-ignore-static")) {
@@ -369,7 +369,7 @@ export function embedAssets(filepath: string, state: State, assets: {[key:string
             // Get the extension of image.
             // (We need to specify the extension for data url.)
             const ext = imgURL.split(".").pop();
-            const mimeType = mime.lookup(ext) || "png";
+            const mimeType = mime.lookup(ext) || "image/png";
             node.setAttribute("src", `data:${mimeType};base64,${assets[imgURL]}`);
           }
           break;

--- a/packages/spear-cli/src/utils/file.ts
+++ b/packages/spear-cli/src/utils/file.ts
@@ -11,15 +11,17 @@ import { SpearLog } from "./log";
 export class FileUtil {
   manipulator: FileManipulatorInterface;
   logger: SpearLog
-  constructor(manipulator: FileManipulatorInterface, logger: SpearLog) {
+  constructor(manipulator: FileManipulatorInterface, logger: SpearLog, browserMode?: boolean) {
     this.manipulator = manipulator;
     this.logger = logger;
 
     // Define isTTY for sass compilation in the browser.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    process.stdout = {
-      isTTY: true
+    if (browserMode) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      process.stdout = {
+        isTTY: true
+      }
     }
   }
 

--- a/packages/spear-cli/yarn.lock
+++ b/packages/spear-cli/yarn.lock
@@ -2786,10 +2786,10 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-sass@^1.63.6:
-  version "1.63.6"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.63.6.tgz#481610e612902e0c31c46b46cf2dad66943283ea"
-  integrity sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==
+sass@^1.69.2:
+  version "1.69.3"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.3.tgz#f8a0c488697e6419519834a13335e7b65a609c11"
+  integrity sha512-X99+a2iGdXkdWn1akFPs0ZmelUzyAQfvqYc2P/MPTrJRuIRoTffGzT9W9nFqG00S+c8hXzVmgxhUuHFdrwxkhQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"


### PR DESCRIPTION
## Overview

- We introduced a custom importer because there was a problem where importing did not work properly when using `@use` or `@forward` in browser mode.
- https://sass-lang.com/documentation/js-api/interfaces/importer/

## 概要

- ブラウザモードで `@use` や `@forward` を使うとうまくインポートできずにコンパイルに失敗する問題があったため、カスタムインポーターを導入しました。
- https://sass-lang.com/documentation/js-api/interfaces/importer/