### PR TITLE
Supporting Pagination feature / ページネーション機能のサポート

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.4.7",
+      "version": "1.4.9",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.4.7",
+  "version": "1.4.9",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -74,6 +74,20 @@ export interface BundleHookFunction {
 }
 
 /**
+ * Call when generating pagination navigation element.
+ * If return empty string, generating default pagination navigation.
+ * 
+ * fname: file name including [pagination].
+ * page: current page element.
+ * loopId: loop id.
+ * targetSource: target source object.
+ * sources: all sources object.
+ */
+export interface PaginationHookFunction {
+    (fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>):  string
+}
+
+/**
  * Hook API structure.
  * You can specify this object into spear.config.mjs.
  */
@@ -83,4 +97,5 @@ export interface HookApi {
     beforeBuild?: BeforeBuildHookFunction,
     afterBuild? : AfterBuildHookFunction,
     bundle? : BundleHookFunction,
+    pagination? : PaginationHookFunction
 }

--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -87,7 +87,7 @@ export interface BundleHookFunction {
  * sources: all sources object.
  */
 export interface PaginationHookFunction {
-  (fname: string, page: Element, loopId: string, targetSource: SpearPaginationElement, sources: Array<SpearPaginationElement>):  string
+  (fname: string, page: Element, loopId: string, targetSource: SpearPaginationElement, sources: SpearPaginationElement[]):  string
 }
 
 /**

--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -3,6 +3,7 @@ import { HTMLElement } from "node-html-parser"
 import { FileUtil } from "../utils/file"
 import { SpearLog } from "../utils/log"
 import { SpearlyJSGenerator } from "@spearly/cms-js-core"
+import { PaginationElement } from "./MagicInterfaces"
 
 export type SpearSettings = DefaultSettings
 
@@ -36,6 +37,8 @@ export interface SpearOption {
   fileUtil: FileUtil,
   logger: SpearLog
 }
+
+export type SpearPaginationElement = PaginationElement;
 
 /**
  * Call after configuration has finished.
@@ -84,7 +87,7 @@ export interface BundleHookFunction {
  * sources: all sources object.
  */
 export interface PaginationHookFunction {
-  (fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>):  string
+  (fname: string, page: Element, loopId: string, targetSource: SpearPaginationElement, sources: Array<SpearPaginationElement>):  string
 }
 
 /**

--- a/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
+++ b/packages/spear-cli/src/interfaces/HookCallbackInterface.ts
@@ -84,7 +84,17 @@ export interface BundleHookFunction {
  * sources: all sources object.
  */
 export interface PaginationHookFunction {
-    (fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>):  string
+  (fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>):  string
+}
+
+/**
+ * Call when generating routing pages.
+ * E.g., [pagination].html, [alias].html, [tags].html... etc
+ * If return empty or null, generating default routing pages.
+ * 
+ */
+export interface RoutingHookFunction {
+  (targetPage: Component): Promise<Component[]>
 }
 
 /**
@@ -97,5 +107,6 @@ export interface HookApi {
     beforeBuild?: BeforeBuildHookFunction,
     afterBuild? : AfterBuildHookFunction,
     bundle? : BundleHookFunction,
-    pagination? : PaginationHookFunction
+    pagination? : PaginationHookFunction,
+    routing? : RoutingHookFunction,
 }

--- a/packages/spear-cli/src/interfaces/MagicInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/MagicInterfaces.ts
@@ -32,3 +32,9 @@ export interface SiteMapURL {
   changefreq: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never",
   priority: number,
 }
+
+export interface PaginationElement {
+  element: Element,
+  count: number,
+  currentPage: number
+}

--- a/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
+++ b/packages/spear-cli/src/interfaces/SettingsInterfaces.ts
@@ -25,4 +25,5 @@ export interface DefaultSettings {
   embedMode? : boolean,
   debugMode? : boolean,
   generateComponents?: boolean,
+  maxPaginationCount?: number,
 }

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -105,10 +105,7 @@ async function bundle(): Promise<boolean> {
   // Due to support nested components.
   const componentsList = [] as Component[]
   for (const component of state.componentsList) {
-    const parsedNode = 
-      component.fname.includes("[pagination]") 
-      ? await parseElements(state, component.node.childNodes as Element[], state.jsGenerator, settings) as Element[]
-      : component.node.childNodes as Element[];
+    const parsedNode = await parseElements(state, component.node.childNodes as Element[], state.jsGenerator, settings) as Element[]
     componentsList.push({
       "fname": component.fname,
       "rawData": parsedNode[0].outerHTML,
@@ -119,21 +116,14 @@ async function bundle(): Promise<boolean> {
   }
   state.componentsList = componentsList
 
-  // Run list again to parse children of the pages
-  const isSkipFileName = (filePath): boolean => {
-    return filePath.includes("[pagination]") ||
-      filePath.includes("[alias]") ||
-      filePath.includes("[tags]");
-  }
+  // generate static routing files.
+  state.pagesList = await generateAliasPagesFromPagesList(state, state.jsGenerator, settings)
+
   for (const page of state.pagesList) {
-    if (isSkipFileName(page.fname)) continue;
     page.node.childNodes = await parseElements(state, page.node.childNodes as Element[], state.jsGenerator, settings)
     // We need to parseElement twice due to embed nested component.
     page.node.childNodes = await parseElements(state, page.node.childNodes as Element[], state.jsGenerator, settings)
   }
-
-  // generate static routing files.
-  state.pagesList = await generateAliasPagesFromPagesList(state, state.jsGenerator, settings)
 
   // Hook API: afterBuild
   for (const plugin of settings.plugins) {

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -5,6 +5,7 @@ import { minify } from "html-minifier-terser";
 import { GetContentOption, SpearlyJSGenerator } from "@spearly/cms-js-core"
 import { generateAPIOptionMap } from "./util.js";
 import { SpearSettings } from "../interfaces/HookCallbackInterface";
+import { DefaultSettings } from "../interfaces/SettingsInterfaces";
 
 function extractProps(state: State, node: Element) {
   const { key, value, scoped } = node.attributes;
@@ -127,40 +128,86 @@ export async function generateAliasPagesFromPagesList(
     if (page.fname.includes("[pagination]")) {
       // Pagination Routing
       const loopElement = page.node.querySelector("[cms-loop]");
-      console.log(loopElement);
-      if (!loopElement) throw new Error("You should specify the cms-loop");
+      if (!loopElement) {
+        console.log(page.node.innerHTML);
+        throw new Error("You should specify the cms-loop");
+      }
       const hasTagLoop  = loopElement.hasAttribute("cms-tag-loop");
-
-      console.log("🙈🙉🙊");
-      console.log(page);
+      const paginationSize = parseInt(loopElement.getAttribute("cms-pagination-size")) || 10;
 
       if (loopElement && hasTagLoop) {
-        console.log("😺😺😺😺😺😺");
         // combination of pagination and tag
         const tagFieldName = loopElement.getAttribute("cms-tag-loop");
         const contentType  = loopElement.getAttribute("cms-content-type");
+        const loopId       = loopElement.getAttribute("cms-loop-id");
         if (!tagFieldName) throw new Error("You should specify the cms-tag-loop");
         if (!contentType)  throw new Error("You should specify the cms-content-type");
 
-        const apiOption = generateAPIOptionMap(loopElement as Element)
-        apiOption.set('limit', 1000);
+        const apiOption = generateAPIOptionMap(loopElement as Element);
+        apiOption.set('limit', settings.maxPaginationCount);
         removeCMSAttributes(loopElement as Element);
         if (settings.debugMode) {
           loopElement.setAttribute("data-spear-content-type", `{%= ${contentType}_#content_type %}`);
           loopElement.setAttribute("data-spear-content", `{%= ${contentType}_#alias %}`);
         }
         const generatedContents = await jsGenerator.generateEachContentFromList(
-          loopElement.innerHTML,
+          loopElement.outerHTML,
           contentType,
           apiOption,
           tagFieldName,
           settings.debugMode
         );
-        generatedContents.forEach(c => {
-          console.log('--------------');
-          console.log(c);
-          console.log('--------------');
-        })
+        const targetLoopElementHTMLTemplate = loopElement.outerHTML;
+        const targetPageHTMLTemplate = page.node.innerHTML;
+        const tagElements: Map<string, Array<{element: Element, count: number, currentPage: number}>> = new Map();
+        generatedContents.forEach((c, i) => {
+          const tags = c.tag;
+          tags.forEach(tag => {
+            if (!tagElements.has(tag)) {
+              const newElement = parse("") as Element;
+              tagElements.set(tag, [{ element: newElement, count: 0, currentPage: 1 }]);
+            }
+            const obj = tagElements.get(tag);
+            const element = obj[obj.length - 1].element;
+            const count = obj[obj.length - 1].count;
+            const currentPage = obj[obj.length - 1].currentPage;
+            const generatedHTML = c.generatedHtml;
+            element.innerHTML += generatedHTML;
+            obj[obj.length - 1] = { element: element, count: count + 1, currentPage: currentPage };
+            if ((count + 1 )>  paginationSize) {
+              const newElement = parse("") as Element;
+              newElement.innerHTML = "";
+              obj.push({ element: newElement, count: 0, currentPage: currentPage + 1 });
+            }
+            tagElements.set(tag, obj);
+          });
+        });
+        tagElements.forEach((v, k) => {
+          const tag = k;
+          v.forEach((obj, i) => {
+            const element = obj.element;
+            const currentPage = obj.currentPage;
+            const html = targetPageHTMLTemplate.replace(
+              targetLoopElementHTMLTemplate,
+              element.outerHTML
+            );
+            const replacedPaginationHTML = replacePaginationTag(
+              settings,
+              page.fname.split("[tag]").join(tag),
+              parse(html) as Element,
+              loopId,
+              obj,
+              v
+            );
+            replacePagesList.push({
+              fname: page.fname.split("[tag]").join(tag).split("[pagination]").join(currentPage.toString()),
+              node: parse(replacedPaginationHTML) as Element,
+              props: page.props,
+              tagName: page.tagName,
+              rawData: html,
+            });
+          });
+        });
       } else if (loopElement) {
         console.log("🐶🐶🐶🐶🐶🐶");
         // pagination
@@ -168,6 +215,7 @@ export async function generateAliasPagesFromPagesList(
         if (!contentType)  throw new Error("You should specify the cms-content-type");
 
         const apiOption = generateAPIOptionMap(loopElement as Element)
+        apiOption.set('limit', settings.maxPaginationCount);
         removeCMSAttributes(loopElement as Element);
         if (settings.debugMode) {
           loopElement.setAttribute("data-spear-content-type", `{%= ${contentType}_#content_type %}`);
@@ -382,6 +430,45 @@ export async function generateAliasPagesFromPagesList(
   }
   return replacePagesList;
 }
+
+
+function replacePaginationTag(settings: DefaultSettings, fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>): string {
+  // TODO: Hook pagination
+  for(const plugin of settings.plugins) {
+    if (plugin.pagination) {
+      const html = plugin.pagination(fname, page, loopId, targetSource, sources);
+      if (html) return html;
+    }
+  };
+  const paginationElement = page.querySelector("[cms-pagination]");
+  if (!paginationElement) return page.innerHTML;
+  const targetLoopId = paginationElement.getAttribute("cms-loop-id");
+  if (targetLoopId !== loopId) return page.innerHTML;
+
+  if (paginationElement.innerHTML === "") {
+    // Generate pagination navigation
+    // T.B.D: We should implement pagination navigation generator.
+  } else {
+    // Replace pagination string
+    // {%= pagination_prev %} is prebvous page link
+    // {%= pagination_next %} is next page link
+    // {%= pagination_current_page %} is current page number
+    // {%= pagination_total %} is total page number
+    const totalPage   = sources.length;
+    const currentPage = targetSource.currentPage;
+    const prevPageNum = currentPage - 1;
+    const nextPageNum = currentPage + 1;
+    const prevPage    = fname.split("[pagination]").join(prevPageNum.toString());
+    const nextPage    = fname.split("[pagination]").join(nextPageNum.toString());
+    const replaceHTML = paginationElement.outerHTML
+      .split("{%= pagination_prev %}").join(prevPage)
+      .split("{%= pagination_next %}").join(nextPage)
+      .split("{%= pagination_current_page %}").join(currentPage.toString())
+      .split("{%= pagination_total %}").join(totalPage.toString());
+    return page.innerHTML.replace(paginationElement.outerHTML, replaceHTML);
+  }
+  return "";
+};
 
 function insertComponentSlot(
   componentElement: Element,

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -138,7 +138,7 @@ export async function generateAliasPagesFromPagesList(
       if (loopElement && hasTagLoop) {
         // Routing Hook
         for (const plugin of settings.plugins) {
-          if (plugin.beforeBuild) {
+          if (plugin.routing) {
             try {
               const pages = await plugin.routing(page);
               if (pages) {
@@ -224,7 +224,7 @@ export async function generateAliasPagesFromPagesList(
       } else if (loopElement) {
         // Routing Hook
         for (const plugin of settings.plugins) {
-          if (plugin.beforeBuild) {
+          if (plugin.routing) {
             try {
               const pages = await plugin.routing(page);
               if (pages) {
@@ -325,7 +325,7 @@ export async function generateAliasPagesFromPagesList(
         if (page.fname.includes("[alias]")) {
           // Routing Hook
           for (const plugin of settings.plugins) {
-            if (plugin.beforeBuild) {
+            if (plugin.routing) {
               try {
                 const pages = await plugin.routing(page);
                 if (pages) {
@@ -383,7 +383,7 @@ export async function generateAliasPagesFromPagesList(
       } else if (tagAndLoopElement && !tagAndLoopElement.getAttribute("cms-ignore-static")) {
         // Routing Hook
         for (const plugin of settings.plugins) {
-          if (plugin.beforeBuild) {
+          if (plugin.routing) {
             try {
               const pages = await plugin.routing(page);
               if (pages) {
@@ -437,7 +437,7 @@ export async function generateAliasPagesFromPagesList(
       } else if (aliasLoopElement && !aliasLoopElement.getAttribute("cms-ignore-static")) {
         // Routing Hook
         for (const plugin of settings.plugins) {
-          if (plugin.beforeBuild) {
+          if (plugin.routing) {
             try {
               const pages = await plugin.routing(page);
               if (pages) {
@@ -495,7 +495,7 @@ export async function generateAliasPagesFromPagesList(
     } else if (page.fname.includes("[alias]")) {
       // Routing Hook
       for (const plugin of settings.plugins) {
-        if (plugin.beforeBuild) {
+        if (plugin.routing) {
           try {
             const pages = await plugin.routing(page);
             if (pages) {

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -171,7 +171,7 @@ export async function generateAliasPagesFromPagesList(
         );
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
-        const tagElements: Map<string, Array<PaginationElement>> = new Map();
+        const tagElements: Map<string, PaginationElement[]> = new Map();
         generatedContents.forEach((c, i) => {
           const tags = c.tag;
           tags.forEach(tag => {
@@ -256,7 +256,7 @@ export async function generateAliasPagesFromPagesList(
 
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
-        const elements: Array<PaginationElement> = [{ element: parse("") as Element, count: 0, currentPage: 1}];
+        const elements: PaginationElement[] = [{ element: parse("") as Element, count: 0, currentPage: 1}];
         generatedContents.forEach((c, i) => {
           let lastItem = elements[elements.length - 1];
           const element  = lastItem.element;
@@ -548,7 +548,7 @@ export async function generateAliasPagesFromPagesList(
 }
 
 
-function replacePaginationTag(settings: DefaultSettings, fname: string, page: Element, loopId: string, targetSource: PaginationElement, sources: Array<PaginationElement>): string {
+function replacePaginationTag(settings: DefaultSettings, fname: string, page: Element, loopId: string, targetSource: PaginationElement, sources: PaginationElement[]): string {
   // TODO: Hook pagination
   for(const plugin of settings.plugins) {
     if (plugin.pagination) {

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -194,8 +194,7 @@ export async function generateAliasPagesFromPagesList(
             tagElements.set(tag, obj);
           });
         });
-        tagElements.forEach((v, k) => {
-          const tag = k;
+        tagElements.forEach((v, tag) => {
           v.forEach((obj, i) => {
             const element = obj.element;
             const currentPage = obj.currentPage;

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -187,7 +187,7 @@ export async function generateAliasPagesFromPagesList(
             const generatedHTML = c.generatedHtml;
             element.innerHTML += generatedHTML;
             obj[obj.length - 1] = { element: element, count: count + 1, currentPage: currentPage };
-            if ((count + 1 )>  paginationSize) {
+            if ((count + 1 ) >=  paginationSize) {
               const newElement = parse("") as Element;
               newElement.innerHTML = "";
               obj.push({ element: newElement, count: 0, currentPage: currentPage + 1 });
@@ -269,7 +269,7 @@ export async function generateAliasPagesFromPagesList(
           lastItem.element = element;
           lastItem.count = count + 1;
           lastItem.currentPage = currentPage;
-          if ((lastItem.count + 1) >  paginationSize) {
+          if ((lastItem.count + 1) >=  paginationSize) {
             const newElement = parse("") as Element;
             newElement.innerHTML = "";
             elements.push({ element: parse("") as Element, count: 0, currentPage: currentPage + 1});

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -129,7 +129,6 @@ export async function generateAliasPagesFromPagesList(
       // Pagination Routing
       const loopElement = page.node.querySelector("[cms-loop]");
       if (!loopElement) {
-        console.log(page.node.innerHTML);
         throw new Error("You should specify the cms-loop");
       }
       const hasTagLoop  = loopElement.hasAttribute("cms-tag-loop");

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -1,4 +1,4 @@
-import { Component, Element, State } from "../interfaces/MagicInterfaces";
+import { Component, Element, PaginationElement, State } from "../interfaces/MagicInterfaces";
 import { parse } from "node-html-parser";
 import mime from "mime-types";
 import { minify } from "html-minifier-terser";
@@ -171,7 +171,7 @@ export async function generateAliasPagesFromPagesList(
         );
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
-        const tagElements: Map<string, Array<{element: Element, count: number, currentPage: number}>> = new Map();
+        const tagElements: Map<string, Array<PaginationElement>> = new Map();
         generatedContents.forEach((c, i) => {
           const tags = c.tag;
           tags.forEach(tag => {
@@ -256,7 +256,7 @@ export async function generateAliasPagesFromPagesList(
 
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
-        const elements: Array<{element: Element, count: number, currentPage: number}> = [{ element: parse("") as Element, count: 0, currentPage: 1}];
+        const elements: Array<PaginationElement> = [{ element: parse("") as Element, count: 0, currentPage: 1}];
         generatedContents.forEach((c, i) => {
           let lastItem = elements[elements.length - 1];
           const element  = lastItem.element;
@@ -548,7 +548,7 @@ export async function generateAliasPagesFromPagesList(
 }
 
 
-function replacePaginationTag(settings: DefaultSettings, fname: string, page: Element, loopId: string, targetSource: {element: Element, count: number, currentPage: number}, sources: Array<{element: Element, count: number, currentPage: number}>): string {
+function replacePaginationTag(settings: DefaultSettings, fname: string, page: Element, loopId: string, targetSource: PaginationElement, sources: Array<PaginationElement>): string {
   // TODO: Hook pagination
   for(const plugin of settings.plugins) {
     if (plugin.pagination) {

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -88,7 +88,10 @@ export function generateAPIOptionMap(node: Element): APIOption {
       case "filters":
         // For now, Spear doesn't support multiple specify.
         break
-
+    }
+    if (key.startsWith("cms-option-order_by_")) {
+      const cmsKey = key.replace("cms-option-", "");
+      apiOptions.set(cmsKey, value);
     }
   }
   return apiOptions


### PR DESCRIPTION
## What is this PR?

This PR will support pagination generating which relating with #126.

This PR support the following features:

### 1. Generating the pagination page which contain the tag and page number.

If file path contain the `[tag]` and `[pagination]`, Spear will generate the pagination pages including the tag.

For example, if the path is `/blog/[tag]/[pagination]/index.html`, Spear will generate the following pages.
- /blog/tagA/1/index.html
- /blog/tagA/2/index.html
- /blog/tagB/1/index.html
- /blog/tagC/1/index.html

This feature is enabled when specifying the `cms-loop` and `cms-tag-loop` and `cms-content-type`.
Example:

```html
<html>
 <body>
  <div cms-loop cms-tag-loop="tags" cms-content-type="blog">
   {%= blog_title %}
  </div>
 </body>
</html>
```

### 2. Generating the pagination page which is only page number.

If file path contain and `[pagination]`, Spear will generate the pagination pages. 

For example, if the path is `/blog/[pagination]/index.html`, Spear will generate the following pages.
- /blog/1/index.html
- /blog/2/index.html
- /blog/3/index.html
- /blog/4/index.html

This feature is enabled when specifying the `cms-loop` and `cms-content-type`.
Example:

```html
<html>
 <body>
  <div cms-loop cms-content-type="blog">
   {%= blog_title %}
  </div>
 </body>
</html>
```

### 3. Generating the pagination navigation.

This feature support the pagination navigation tag:

| tag | replaced value |
| - | - |
| {%= pagination_prev %} | Previous page's link.  |
| {%= pagination_next %} | Next page's link |
| {%= pagination_current_page %} | Current page number |
| {%= pagination_total %} | total page number |

This generated navigation is related by `cms-loop-id` attribute:

```html
<div cms-loop cms-content-type="blog" cms-loop-id="loop-id-1">
  <h1>{%= blog_title %}</h1>
</div>

<!-- This nav is related by "loop-id-1" attribute -->
<div cms-pagination cms-loop-id="loop-id-1">
  <a href="{%= pagination_prev %}">[Prev]</a>
  <p>{%= pagination_current_page %} / {%= pagination_total %}</p>
  <a href="{%= pagination_next %}">[Next]</a>
</div>
```

### 4. Support the hook of generating route and generating the pagination navigation.

This PR will add the following hook for customizing via plugin:

- Generating route hook
  - When generating pagination routing page, the spear will call the `routing` hook.
  - If this hook return the page list, spear use it.
- Generating pagination navigation hook
  - When generating pagination navigation, the spear will call the `pagination` hook.
  - If this hook return the page html string, spear use it.

-------
## このPRについて

この PR は #126 に関連するページネーションページ生成をサポートするものです。

この PR は以下の機能をサポートします。

###  1. タグとページ番号を含むページネーションページを生成します。

もしパスに `[tag]` と `[pagination]` が含まれる場合、Spear はタグを含むページネーションページを生成します。

例えば、パスが  `/blog/[tag]/[pagination]/index.html` だった場合、Spear は以下のページを生成します。
- /blog/tagA/1/index.html
- /blog/tagA/2/index.html
- /blog/tagB/1/index.html
- /blog/tagC/1/index.html

この機能は `cms-loop` と `cms-tag-loop` と `cms-content-type` が指定されたときにのみ有効になります。

例:

```html
<html>
 <body>
  <div cms-loop cms-tag-loop="tags" cms-content-type="blog">
   {%= blog_title %}
  </div>
 </body>
</html>
```

### 2. ページ番号のみのページネーションファイルを生成

もしパスに `[pagination]` が含まれる場合、Spear はページネーションページを生成ます。

例えばパスが `/blog/[pagination]/index.html` だった場合、Spear は以下のページを生成します。
- /blog/1/index.html
- /blog/2/index.html
- /blog/3/index.html
- /blog/4/index.html

この機能は `cms-loop` と `cms-content-type` が指定されたときにのみ有効になります。

例:

```html
<html>
 <body>
  <div cms-loop cms-content-type="blog">
   {%= blog_title %}
  </div>
 </body>
</html>
```

### 3. ページネーションのナビゲーションを生成

この機能では、ページネーションのナビゲーションを作るために以下の文字列を置換します。

| tag | 置換後の値 |
| - | - |
| {%= pagination_prev %} | 前のページのリンク |
| {%= pagination_next %} | 次のページのリンク |
| {%= pagination_current_page %} | 現在のページ番号 |
| {%= pagination_total %} | トータルのページ数 |

ナビゲーションの生成は `cms-loop-id` に関連します。

```html
<div cms-loop cms-content-type="blog" cms-loop-id="loop-id-1">
  <h1>{%= blog_title %}</h1>
</div>

<!-- This nav is related by "loop-id-1" attribute -->
<div cms-pagination cms-loop-id="loop-id-1">
  <a href="{%= pagination_prev %}">[Prev]</a>
  <p>{%= pagination_current_page %} / {%= pagination_total %}</p>
  <a href="{%= pagination_next %}">[Next]</a>
</div>
```

### 4. ページネーション生成とナビゲーション生成時のフック機能サポート

この PR はプラグイン経由でカスタマイズ可能にするために以下のフック機能をサポートしています。

- ページネーション生成時のフック
  - ページネーションのルーティングを生成する際に Spear は `routIng` フックを実行します。
  - もしこのフックの結果ページリストが返ってきた場合は Spear はそのページリストを利用します。
- ページネーションのナビゲーション生成時のフック
  - ページネーションのナビゲーション生成時に Spear は `pagination` ホックを実行します。
  - もしこのフックの結果ページのHTMLが返ってきた場合、Spear はその HTML を利用します。


