### PR TITLE
Spearly CMS API オプションの修正 / Fix Spearly CMS API Options

### DIFF
--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -66,27 +66,23 @@ export function generateAPIOptionMap(node: Element): APIOption {
         apiOptions.set(cmsKey, parseInt(value))
         node.removeAttribute(key)
         break
-      case "order":
-      case "orderDirection":
-      case "orderBy":
-      case "filterBy":
-      case "filterRef":
-      case "filterMode":
-        apiOptions.set(cmsKey, value)
-        node.removeAttribute(key)
-        break
       case "rangeFrom":
       case "rangeTo":
         apiOptions.set(cmsKey, new Date(value))
         node.removeAttribute(key)
         break
       case "filterValue": 
+      case "filter_value":
         apiOptions.set(cmsKey, [...value.split(",")])
         node.removeAttribute(key)
         break
       case "orders":
       case "filters":
         // For now, Spear doesn't support multiple specify.
+        break
+      default:
+        apiOptions.set(cmsKey, value)
+        node.removeAttribute(key)
         break
     }
     if (key.startsWith("cms-option-order_by_")) {


### PR DESCRIPTION
## 変更点

Spearly CMS API のオプションを指定した際に、正しい API オプションの指定が出来ていなかったため修正をしています。

```
<div cms-item cms-content-type="sample" cms-option-filterBy="test" cms-option-filterValue="value">
....
</div>
```

本来だったら、 `filter_by` / `filter_value` が正しいフィルターのキーになりますが、間違ったオプションになっていたため、フィルターが失敗していました。

## Changes

This patch will fix the CMS API option key. Previous implementation is wrong this key.

Example:

```
<div cms-item cms-content-type="sample" cms-option-filterBy="test" cms-option-filterValue="value">
....
</div>
```

This sample's key is `filterBy` and `filterValue`. This key is wrong, correctly this key should be `filter_by` / `filter_value`.
As result of this wrong implement, generated page included all of content.