### PR TITLE
version up & skip dropping unrelated attribute

### DIFF
--- a/packages/spear-cli/package-lock.json
+++ b/packages/spear-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.4.11",
+  "version": "1.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spearly/spear-cli",
-      "version": "1.4.11",
+      "version": "1.4.13",
       "license": "MIT",
       "dependencies": {
         "@spearly/cms-js-core": "^1.0.9",

--- a/packages/spear-cli/package.json
+++ b/packages/spear-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spearly/spear-cli",
-  "version": "1.4.11",
+  "version": "1.4.13",
   "type": "module",
   "description": "",
   "preferGlobal": true,

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -58,6 +58,8 @@ export function generateAPIOptionMap(node: Element): APIOption {
   if (!attrs || Object.keys(attrs).length <= 0) return apiOptions
 
   for (const key in attrs) {
+    if (!key.includes("cms-option-")) continue;
+
     const value = attrs[key]
     const cmsKey = key.replace("cms-option-", "")
     switch(cmsKey) {


### PR DESCRIPTION
## Changes

1. Version up

1.4.11 -> 1.4.13 (v1.4.12 is released version)

2. Skip Dropping unrelated attribute

When generating API options from element's attribute, Spear drop the class attribute by mistake.  
