### PR TITLE
fix: build/show dummy component for empty files in order not to abort build /ファイルが空の場合は仮コンポーネントをビルドしてビルドエラーを避ける

### DIFF
--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -106,13 +106,26 @@ async function bundle(): Promise<boolean> {
   const componentsList = [] as Component[]
   for (const component of state.componentsList) {
     const parsedNode = await parseElements(state, component.node.childNodes as Element[], state.jsGenerator, settings) as Element[]
-    componentsList.push({
-      "fname": component.fname,
-      "rawData": parsedNode[0].outerHTML,
-      "tagName": component.tagName,
-      "node": parsedNode[0],
-      "props": {}
-    })
+
+    if (parsedNode[0]) {
+      componentsList.push({
+        "fname": component.fname,
+        "rawData": parsedNode[0].outerHTML,
+        "tagName": component.tagName,
+        "node": parsedNode[0],
+        "props": {}
+      })
+    } else {
+      const fakeNode = parse(`<div>a component ${component.fname} is empty.</div>`) as Element
+
+      componentsList.push({
+        "fname": component.fname,
+        "rawData": fakeNode.outerHTML,
+        "tagName": component.tagName,
+        "node": fakeNode,
+        "props": {}
+      })
+    }
   }
   state.componentsList = componentsList
 


### PR DESCRIPTION
## Summary 概要

Fix for #199 

- The problem comes from reference to undefined attributes created by parsing empty html/spear files. To avoid it. in case of parsing empty files, the script inserts a dummy component.

#### Spec
- shows '<div>a component {component name} is empty.</div>' on the web page

#### Another problem
with this change, `spear watch` won't stop with empty components but logger showing error messages below

```shell
[Page]: /index
BadRequestError: Bad Request
    at createHttpError (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/send/index.js:979:12)
    at SendStream.error (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/send/index.js:270:31)
    at SendStream.pipe (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/send/index.js:516:10)
    at /Users/name/Documents/projects/spear/packages/spear-cli/node_modules/live-server/index.js:97:5
    at call (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/connect/index.js:239:7)
    at next (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/connect/index.js:183:5)
    at Function.handle (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/connect/index.js:186:3)
    at Server.app (/Users/name/Documents/projects/spear/packages/spear-cli/node_modules/connect/index.js:51:37)
    at Server.emit (node:events:390:28)
    at parserOnIncoming (node:_http_server:951:12)
```
