### PR TITLE
Replace SEO Ttitle when existing title tag.

### DIFF
--- a/packages/spear-cli/src/plugins/spear-seo.ts
+++ b/packages/spear-cli/src/plugins/spear-seo.ts
@@ -75,8 +75,14 @@ async function generateSEOBeforeBundle(state: SpearState, logger: SpearLog): Pro
             const headerTag = indexNode.querySelector("head")
             Object.keys(spearSEOTag.attributes).forEach((k) => {
                 if (k === "title") {
-                    const titleTag = parse(`<title>${spearSEOTag.attributes[k]}</title>`)
-                    headerTag.appendChild(titleTag)
+                    const existTitleTag = headerTag.querySelector("title");
+                    // MEMO: If title tag already exists, replace it.
+                    if (existTitleTag) {
+                        existTitleTag.set_content(spearSEOTag.attributes[k])
+                    } else {
+                        const titleTag = parse(`<title>${spearSEOTag.attributes[k]}</title>`)
+                        headerTag.appendChild(titleTag)
+                    }
                 } else if (k.startsWith("meta-")) {
                     const metaName = k.replace("meta-", "")
                     const metaValue = spearSEOTag.attributes[k]


### PR DESCRIPTION
## Overview

- If page has title tag, spear-cli's SEO process replace it.

Example:

```
<html>
  <head>
   <title>Test site</title>
  </head>
  <body>
    <div cms-item cms-content-type="blog" cms-content="first-blog"
      <spear-seo
         title="{%= blog_title %}"
       /></spear-seo>
    </div>
  </body>
</html>
```

An above example has `<title>Test site</title>`, then spear will generate the following HTML:

```
<html>
  <head>
   <title>First Blog Title!</title>
  </head>
  <body>
    <div>
    </div>
  </body>
</html>
```