### PR TITLE
Lint エラー対応

### DIFF
--- a/packages/spear-cli/src/file/InMemoryFileManipulator.ts
+++ b/packages/spear-cli/src/file/InMemoryFileManipulator.ts
@@ -12,8 +12,6 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
         const jsonObject = this.extractInMemoryFilesToObject(files, "/")
         vol.fromJSON(jsonObject, '/')
 
-        const ret = fs.readdirSync('/src')
-
         this.files = files
         this.settingsObject = settingsObject
     }
@@ -71,7 +69,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
         return fs.lstatSync(path).isDirectory()
     }
 
-    mkDirSync(path: string, option: any): void {
+    mkDirSync(path: string, option: { recursive: boolean } | null): void {
         if (option && option.recursive) {
             fs.mkdirSync(path, { recursive: true })
         } else {
@@ -79,7 +77,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
         }
     }
 
-    rmSync(path: string, option: any): void {
+    rmSync(path: string, option: { recursive: boolean } | null): void {
         if (!this.existsSync(path)) return
         if (option.recursive && this.isDirectory(path)) {
             const files = this.readdirSync(path)
@@ -95,7 +93,7 @@ export class InMemoryFileManipulator implements FileManipulatorInterface {
         return fs.writeFileSync(path, content)
     }
 
-    loadFile(pathPattern: string): any {
+    loadFile(): Promise<DefaultSettings> {
         return Promise.resolve(this.settingsObject)
     }
 

--- a/packages/spear-cli/src/file/LocalFileManipulator.ts
+++ b/packages/spear-cli/src/file/LocalFileManipulator.ts
@@ -7,9 +7,10 @@ import * as sass from "sass"
 import { SiteMapURL } from "../interfaces/MagicInterfaces";
 import { SitemapStream, streamToPromise } from "sitemap";
 import { Readable } from "stream";
+import { DefaultSettings } from "../types";
 
 export class LocalFileManipulator implements FileManipulatorInterface {
-    loadFile(filePath: string): any {
+    loadFile(filePath: string): Promise<DefaultSettings> {
         return new Promise((resolve, reject) => {
           glob(filePath, null, async (er, files) => {
             if (er) {
@@ -32,7 +33,7 @@ export class LocalFileManipulator implements FileManipulatorInterface {
                 const data = this.readFileSync(files[0], "utf8");
                 resolve(yamlParse(data));
               } else {
-                resolve(this.readFileSync(files[0], "utf8"));
+                resolve(JSON.parse(this.readFileSync(files[0], "utf8")));
               }
             } else {
               resolve(null);
@@ -56,11 +57,11 @@ export class LocalFileManipulator implements FileManipulatorInterface {
     isDirectory(filePath: string): boolean {
         return fs.lstatSync(filePath).isDirectory()
     }
-    mkDirSync(filePath: string, option: any): void {
+    mkDirSync(filePath: string, option: { recursive: boolean } | null): void {
         fs.mkdirSync(filePath, option)
         return
     }
-    rmSync(filePath: string, option: any): void {
+    rmSync(filePath: string, option: { recursive: boolean } | null): void {
       fs.rmSync(filePath, option)
       return
     }

--- a/packages/spear-cli/src/interfaces/FileManipulatorInterface.ts
+++ b/packages/spear-cli/src/interfaces/FileManipulatorInterface.ts
@@ -7,10 +7,10 @@ export interface FileManipulatorInterface {
   readdirSync: (path: string) => string[];
   existsSync: (path: string) => boolean;
   isDirectory: (path: string) => boolean;
-  mkDirSync: (path: string, option: any) => void;
-  rmSync: (path: string, option: any) => void;
+  mkDirSync: (path: string, option: { recursive: boolean } | null) => void;
+  rmSync: (path: string, option: { recursive: boolean } | null) => void;
   writeFileSync: (path: string, content: string) => void;
-  loadFile: (path: string) => any;
+  loadFile: (path: string) => Promise<DefaultSettings>;
   compileSASS: (path: string) => string;
   generateSiteMap: (linkList: Array<SiteMapURL>, siteURL: string) => Promise<string>;
   debug: () => void;

--- a/packages/spear-cli/src/magic.ts
+++ b/packages/spear-cli/src/magic.ts
@@ -243,6 +243,7 @@ export default async function magic(args: Args): Promise<boolean> {
       middleware:
         settings.crossOriginIsolation
           ? [
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               function (req: any, res: any, next: any) {
                 res.setHeader("Cross-Origin-Embedder-Policy", "credentialless")
                 res.setHeader("Cross-Origin-Opener-Policy", "same-origin")

--- a/packages/spear-cli/src/utils/dom.ts
+++ b/packages/spear-cli/src/utils/dom.ts
@@ -84,7 +84,7 @@ export async function parseElements(state: State, nodes: Element[], jsGenerator:
         node.setAttribute("data-spear-content-type", `{%= ${contentType}_#content_type %}`);
         node.setAttribute("data-spear-content", `{%= ${contentType}_#alias %}`);
       }
-      const [generatedStr, _] = await jsGenerator.generateContent(
+      const [ generatedStr ] = await jsGenerator.generateContent(
         node.outerHTML,
         contentType,
         contentId,
@@ -172,7 +172,7 @@ export async function generateAliasPagesFromPagesList(
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
         const tagElements: Map<string, PaginationElement[]> = new Map();
-        generatedContents.forEach((c, i) => {
+        generatedContents.forEach((c) => {
           const tags = c.tag;
           tags.forEach(tag => {
             if (!tagElements.has(tag)) {
@@ -195,7 +195,7 @@ export async function generateAliasPagesFromPagesList(
           });
         });
         tagElements.forEach((v, tag) => {
-          v.forEach((obj, i) => {
+          v.forEach((obj) => {
             const element = obj.element;
             const currentPage = obj.currentPage;
             const html = targetPageHTMLTemplate.replace(
@@ -256,8 +256,8 @@ export async function generateAliasPagesFromPagesList(
         const targetLoopElementHTMLTemplate = loopElement.outerHTML;
         const targetPageHTMLTemplate = page.node.innerHTML;
         const elements: PaginationElement[] = [{ element: parse("") as Element, count: 0, currentPage: 1}];
-        generatedContents.forEach((c, i) => {
-          let lastItem = elements[elements.length - 1];
+        generatedContents.forEach((c) => {
+          const lastItem = elements[elements.length - 1];
           const element  = lastItem.element;
           const count    = lastItem.count;
           const currentPage = lastItem.currentPage;
@@ -273,7 +273,7 @@ export async function generateAliasPagesFromPagesList(
             elements.push({ element: parse("") as Element, count: 0, currentPage: currentPage + 1});
           }
         });
-        elements.forEach((v, i) => {
+        elements.forEach((v) => {
           const element = v.element;
           const currentPage = v.currentPage;
           const html = targetPageHTMLTemplate.replace(
@@ -558,7 +558,7 @@ function replacePaginationTag(settings: DefaultSettings, fname: string, page: El
         console.warn(` plugin process failed. ${plugin.pluginName}}`);
       }
     }
-  };
+  }
   const paginationElement = page.querySelector("[cms-pagination]");
   if (!paginationElement) return page.innerHTML;
   const targetLoopId = paginationElement.getAttribute("cms-loop-id");
@@ -587,7 +587,7 @@ function replacePaginationTag(settings: DefaultSettings, fname: string, page: El
     return page.innerHTML.replace(paginationElement.outerHTML, replaceHTML);
   }
   return "";
-};
+}
 
 function insertComponentSlot(
   componentElement: Element,

--- a/packages/spear-cli/src/utils/file.ts
+++ b/packages/spear-cli/src/utils/file.ts
@@ -25,7 +25,7 @@ export class FileUtil {
     }
   }
 
-  loadFile(filePath: string): Promise<any> {
+  loadFile(filePath: string): Promise<DefaultSettings> {
     return this.manipulator.loadFile(filePath);
   }
 

--- a/packages/spear-cli/src/utils/log.ts
+++ b/packages/spear-cli/src/utils/log.ts
@@ -12,18 +12,21 @@ export class SpearLog {
         this.quite = value;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     log(...args: any[]) {
         if (!this.quite) {
             console.log(...args);
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     warn(...args: any[]) {
         if (!this.quite) {
             console.warn(...args);
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     error(...args: any[]) {
         if (!this.quite) {
             console.error(...args);

--- a/packages/spear-cli/src/utils/util.ts
+++ b/packages/spear-cli/src/utils/util.ts
@@ -54,7 +54,7 @@ export function defaultSettingDeepCopy(config: DefaultSettings): DefaultSettings
 
 export function generateAPIOptionMap(node: Element): APIOption {
   const attrs = node.attributes
-  const apiOptions = new Map<string, any>()
+  const apiOptions = new Map<string, number | Date | string[] | string>()
   if (!attrs || Object.keys(attrs).length <= 0) return apiOptions
 
   for (const key in attrs) {


### PR DESCRIPTION
## Overview:

 - spear-cli で用意していた `eslint` でエラーになる箇所があったたので修正しています。


```
/home/mantaroh/code/spear/packages/spear-cli/src/file/InMemoryFileManipulator.ts
  15:15  warning  'ret' is assigned a value but never used  @typescript-eslint/no-unused-vars
  74:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  82:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  98:14  warning  'pathPattern' is defined but never used   @typescript-eslint/no-unused-vars
  98:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/file/LocalFileManipulator.ts
  12:33  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  59:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  63:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/interfaces/FileManipulatorInterface.ts
  10:37  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  11:34  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  13:31  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/magic.ts
  246:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  246:40  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  246:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/utils/dom.ts
   87:28  warning  '_' is assigned a value but never used               @typescript-eslint/no-unused-vars
  175:39  warning  'i' is defined but never used                        @typescript-eslint/no-unused-vars
  198:27  warning  'i' is defined but never used                        @typescript-eslint/no-unused-vars
  259:39  warning  'i' is defined but never used                        @typescript-eslint/no-unused-vars
  260:15  error    'lastItem' is never reassigned. Use 'const' instead  prefer-const
  276:30  warning  'i' is defined but never used                        @typescript-eslint/no-unused-vars
  561:4   error    Unnecessary semicolon                                @typescript-eslint/no-extra-semi
  590:2   error    Unnecessary semicolon                                @typescript-eslint/no-extra-semi

/home/mantaroh/code/spear/packages/spear-cli/src/utils/file.ts
  28:39  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/utils/log.ts
  15:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  21:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  27:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/mantaroh/code/spear/packages/spear-cli/src/utils/util.ts
  57:38  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 27 problems (3 errors, 24 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option.
```